### PR TITLE
添加AOT编译支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@
   - model 应用内传输用类型放这里
 - utils 工具类
 
+## native 编译
+
+1. 安装 [GraalVM](https://github.com/graalvm/graalvm-ce-builds/releases) Java17，并配置好环境变量，部分功能需要正确配置 `JAVA_HOME` 变量为 GraalVM 安装目录才能正常使用
+2. 如果您处于 Windows 环境下，需要安装 `Visual Studio` 并且安装 C++ 组件，Linux 环境下则需要安装 `gcc` 工具链，Mac 下需要安装 `xcode` 工具链，详情查看 [native-image#prerequisites](https://www.graalvm.org/22.3/reference-manual/native-image/#prerequisites)
+3. 通过 `gu install native-image` 安装 `native-image` AOT 编译器
+4. 在该项目目录下，执行 `./gradlew nativeRun` 或者 `.\gradlew.bat nativeRun` 编译并运行该项目
+5. 如果您希望产生 docker image，请执行 `./gradlew bootBuildImage`
+
 ## Join us!
 
 QQ Group: 724540644

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,29 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.0'
+    id 'org.springframework.boot' version '3.0.1'
     id "io.spring.dependency-management" version "1.1.0"
     id "io.freefair.lombok" version "6.6"
+    id 'org.graalvm.buildtools.native' version '0.9.18'
 }
 
 group 'plus.maa'
 version '1.0-SNAPSHOT'
+
+bootBuildImage {
+    builder = 'paketobuildpacks/builder:tiny'
+    environment = ['BP_NATIVE_IMAGE': 'true']
+    imageName = 'maa-backend-center'
+}
 
 repositories {
     maven {
         url 'https://maven.aliyun.com/repository/public/'
     }
     mavenCentral()
+}
+
+ext {
+    set('springCloudVersion', "2022.0.0")
 }
 
 dependencies {
@@ -24,12 +35,17 @@ dependencies {
     //springdoc相关依赖没有被自动管理，必须保留版本号
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
-    //我草 我玩了3小时的spring发邮件 我这个fw玩不明白 告辞 我还是用hutool的吧 :)
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
     implementation 'com.sun.mail:javax.mail:1.6.2'
     implementation 'cn.hutool:hutool-all:5.8.10'
 
-    implementation 'io.github.openfeign:feign-java11:11.9'
-    implementation 'io.github.openfeign:feign-jackson:11.9'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 test {

--- a/src/main/java/plus/maa/backend/config/OpenFeignConfig.java
+++ b/src/main/java/plus/maa/backend/config/OpenFeignConfig.java
@@ -1,34 +1,12 @@
 package plus.maa.backend.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import feign.Feign;
-import feign.http2client.Http2Client;
-import feign.jackson.JacksonDecoder;
-import feign.jackson.JacksonEncoder;
 import org.springframework.boot.SpringBootConfiguration;
-import org.springframework.context.annotation.Bean;
-import plus.maa.backend.repository.GithubRepository;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
-/**
- * @author dragove
- * created on 2022/12/23
- */
+@EnableFeignClients(basePackages = {
+        "plus.maa.backend.repository"
+})
 @SpringBootConfiguration
 public class OpenFeignConfig {
-
-    @Bean
-    public GithubRepository githubRepository() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        // 禁用遇到未知属性抛出异常
-        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
-        return Feign.builder()
-                .client(new Http2Client())
-                .encoder(new JacksonEncoder(objectMapper))
-                .decoder(new JacksonDecoder(objectMapper))
-                .target(GithubRepository.class, "https://api.github.com");
-    }
 
 }

--- a/src/main/java/plus/maa/backend/repository/GithubRepository.java
+++ b/src/main/java/plus/maa/backend/repository/GithubRepository.java
@@ -1,9 +1,8 @@
 package plus.maa.backend.repository;
 
-import feign.Headers;
-import feign.Param;
-import feign.RequestLine;
-import plus.maa.backend.repository.entity.ArknightsTilePos;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import plus.maa.backend.repository.entity.GithubContent;
 
 import java.net.URI;
@@ -13,6 +12,7 @@ import java.util.List;
  * @author dragove
  * created on 2022/12/23
  */
+@FeignClient(value = "githubRepository", url = "https://api.github.com")
 public interface GithubRepository {
 
     /**
@@ -22,21 +22,21 @@ public interface GithubRepository {
      * @param repo  GitHub 仓库名称（含用户名），例如 MaaAssistantArknights/MaaAssistantArknights
      * @param path  文件路径，例如 src
      */
-    @Headers({
+    @GetMapping(value = "/repos/{repo}/contents/{path}", headers = {
             "Accept: application/vnd.github+json",
             "Authorization: {token}",
             "X-GitHub-Api-Version: 2022-11-28"
     })
-    @RequestLine("GET /repos/{repo}/contents/{path}")
-    List<GithubContent> getContents(@Param("token") String token, @Param("repo") String repo,
-                                    @Param("path") String path);
+    List<GithubContent> getContents(@RequestParam("token") String token,
+                                    @RequestParam("repo") String repo,
+                                    @RequestParam("path") String path);
 
     /**
      * 下载
      * @param uri 资源路径
      * @return MAA level json文件
      */
-    @RequestLine("GET")
-    ArknightsTilePos downloadArknightsTilePos(URI uri);
+    @GetMapping
+    String downloadArknightsTilePos(URI uri);
 
 }


### PR DESCRIPTION
使用 `GraalVM` 的 `native-image` 工具链将项目编译成二进制，同时也能直接打包成一个较小的 docker 镜像。