### PR TITLE
关于 query parameters 的形状问题

### DIFF
--- a/src/main/java/plus/maa/backend/config/SpringDocConfig.java
+++ b/src/main/java/plus/maa/backend/config/SpringDocConfig.java
@@ -50,10 +50,11 @@ public class SpringDocConfig {
                 .components(new Components()
                         .addSecuritySchemes(SECURITY_SCHEME_NAME,
                                 new SecurityScheme()
-                                        .type(SecurityScheme.Type.APIKEY)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
                                         .in(SecurityScheme.In.HEADER)
                                         .name(securitySchemeHeader)
-                                        .description("JWT Authorization header using the Bearer scheme. Example: \"%s: Bearer {token}\"".formatted(securitySchemeHeader))
+                                        .description("JWT Authorization header using the Bearer scheme. Raw head example: \"%s: Bearer {token}\"".formatted(securitySchemeHeader))
                         ));
     }
 

--- a/src/main/java/plus/maa/backend/controller/CommentsAreaController.java
+++ b/src/main/java/plus/maa/backend/controller/CommentsAreaController.java
@@ -1,5 +1,6 @@
 package plus.maa.backend.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -19,6 +20,8 @@ import plus.maa.backend.controller.response.CommentsAreaInfo;
 import plus.maa.backend.controller.response.MaaResult;
 import plus.maa.backend.service.CommentsAreaService;
 
+import java.util.Map;
+
 /**
  * @author LoMu
  * Date  2023-02-17 14:56
@@ -31,6 +34,7 @@ import plus.maa.backend.service.CommentsAreaService;
 public class CommentsAreaController {
 
     private final CommentsAreaService commentsAreaService;
+    private final ObjectMapper mapper;
 
     @PostMapping("/add")
     @Operation(summary = "发送评论")
@@ -47,8 +51,12 @@ public class CommentsAreaController {
     @GetMapping("/query")
     @Operation(summary = "分页查询评论")
     @ApiResponse(description = "评论区信息")
-    public MaaResult<CommentsAreaInfo> queriesCommentsArea(@Parameter(description = "评论区") CommentsQueriesDTO commentsQueriesDTO) {
-        return MaaResult.success(commentsAreaService.queriesCommentsArea(commentsQueriesDTO));
+    public MaaResult<CommentsAreaInfo> queriesCommentsArea(
+            @Parameter(description = "评论区") CommentsQueriesDTO commentsQueriesDTO,
+            @Parameter(hidden = true) @RequestParam Map<String, Object> params
+    ) {
+        var parsed = mapper.convertValue(params, CommentsQueriesDTO.class);
+        return MaaResult.success(commentsAreaService.queriesCommentsArea(parsed));
     }
 
     @PostMapping("/delete")

--- a/src/main/java/plus/maa/backend/controller/CopilotController.java
+++ b/src/main/java/plus/maa/backend/controller/CopilotController.java
@@ -1,11 +1,13 @@
 package plus.maa.backend.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.*;
 import plus.maa.backend.common.annotation.JsonSchema;
 import plus.maa.backend.config.SpringDocConfig;
@@ -18,6 +20,8 @@ import plus.maa.backend.controller.response.CopilotPageInfo;
 import plus.maa.backend.controller.response.MaaResult;
 import plus.maa.backend.service.CopilotService;
 
+import java.util.Map;
+
 /**
  * @author LoMu
  * Date  2022-12-25 17:08
@@ -29,6 +33,8 @@ import plus.maa.backend.service.CopilotService;
 @Tag(name = "CopilotController", description = "作业本体管理接口")
 public class CopilotController {
     private final CopilotService copilotService;
+
+    private final ObjectMapper mapper;
 
     @Operation(summary = "上传作业")
     @ApiResponse(description = "上传作业结果")
@@ -72,9 +78,11 @@ public class CopilotController {
     @GetMapping("/query")
     public MaaResult<CopilotPageInfo> queriesCopilot(
             @Parameter(hidden = true) AuthenticationHelper helper,
-            @Parameter(description = "作业查询请求") CopilotQueriesRequest copilotQueriesRequest
+            @Parameter(description = "作业查询请求") @ParameterObject CopilotQueriesRequest copilotQueriesRequest,
+            @Parameter(hidden = true) @RequestParam Map<String, Object> params
     ) {
-        return MaaResult.success(copilotService.queriesCopilot(helper.getUserId(), copilotQueriesRequest));
+        var parsed = mapper.convertValue(params, CopilotQueriesRequest.class);
+        return MaaResult.success(copilotService.queriesCopilot(helper.getUserId(), parsed));
     }
 
     @Operation(summary = "更新作业")

--- a/src/main/java/plus/maa/backend/controller/UserController.java
+++ b/src/main/java/plus/maa/backend/controller/UserController.java
@@ -42,6 +42,7 @@ public class UserController {
     private final UserService userService;
     private final EmailService emailService;
     private final MaaCopilotProperties properties;
+    private final AuthenticationHelper helper;
     @Value("${maa-copilot.jwt.header}")
     private String header;
 
@@ -56,7 +57,6 @@ public class UserController {
     @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)
     @PostMapping("/activate")
     public MaaResult<Void> activate(
-            @Parameter(hidden = true) AuthenticationHelper helper,
             @Parameter(description = "激活用户请求") @Valid @RequestBody ActivateDTO activateDTO
     ) {
         // FIXME 应改为从 body 中获取， 解决激活——登录悖论，待讨论
@@ -74,7 +74,7 @@ public class UserController {
     @ApiResponse(description = "激活码发送结果")
     @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)
     @PostMapping("/activate/request")
-    public MaaResult<Void> activateRequest(@Parameter(hidden = true) AuthenticationHelper helper) {
+    public MaaResult<Void> activateRequest() {
         // FIXME 完成注册后发送激活码不应该由客户端请求
         userService.sendActiveCodeByEmail(helper.requireUserId());
         return MaaResult.success();
@@ -90,7 +90,6 @@ public class UserController {
     @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)
     @PostMapping("/update/password")
     public MaaResult<Void> updatePassword(
-            @Parameter(hidden = true) AuthenticationHelper helper,
             @Parameter(description = "修改密码请求") @RequestBody @Valid PasswordUpdateDTO updateDTO
     ) {
         userService.modifyPassword(helper.requireUserId(), updateDTO.getNewPassword());
@@ -108,7 +107,6 @@ public class UserController {
     @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)
     @PostMapping("/update/info")
     public MaaResult<Void> updateInfo(
-            @Parameter(hidden = true) AuthenticationHelper helper,
             @Parameter(description = "更新用户详细信息请求") @Valid @RequestBody UserInfoUpdateDTO updateDTO
     ) {
         userService.updateUserInfo(helper.requireUserId(), updateDTO);

--- a/src/main/java/plus/maa/backend/controller/request/CommentsQueriesDTO.java
+++ b/src/main/java/plus/maa/backend/controller/request/CommentsQueriesDTO.java
@@ -19,12 +19,4 @@ public class CommentsQueriesDTO {
     private int limit;
     private boolean desc;
     private String orderBy;
-
-    public void setCopilot_id(Long copilotId) {
-        this.copilotId = copilotId;
-    }
-
-    public void setOrder_by(String orderBy) {
-        this.orderBy = orderBy;
-    }
 }

--- a/src/main/java/plus/maa/backend/controller/request/CopilotQueriesRequest.java
+++ b/src/main/java/plus/maa/backend/controller/request/CopilotQueriesRequest.java
@@ -1,14 +1,15 @@
 package plus.maa.backend.controller.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 /**
  * @author LoMu
  * Date  2022-12-26 2:48
  */
+@AllArgsConstructor
 @Data
 public class CopilotQueriesRequest {
-    private String id;
     private int page;
     private int limit;
     private String levelKeyword;

--- a/src/main/java/plus/maa/backend/controller/request/CopilotQueriesRequest.java
+++ b/src/main/java/plus/maa/backend/controller/request/CopilotQueriesRequest.java
@@ -6,7 +6,6 @@ import lombok.Data;
  * @author LoMu
  * Date  2022-12-26 2:48
  */
-
 @Data
 public class CopilotQueriesRequest {
     private String id;
@@ -20,20 +19,6 @@ public class CopilotQueriesRequest {
     private boolean desc;
     private String orderBy;
     private String language;
-
-
-    //params参数 没有这一段spring将无法set参数
-    public void setLevel_keyword(String levelKeyword) {
-        this.levelKeyword = levelKeyword;
-    }
-
-    public void setUploader_id(String uploaderId) {
-        this.uploaderId = uploaderId;
-    }
-
-    public void setOrder_by(String orderBy) {
-        this.orderBy = orderBy;
-    }
 }
 
 


### PR DESCRIPTION
在根据 swagger 产生的文档进行测试时发现若干关于 query parameters 的问题。

经过前面的讨论， json 字段约定为 snake case. 
1. 按照原先代码中的注解，会生成如下的参数解释：
![image](https://user-images.githubusercontent.com/8043546/229336315-d4805162-96df-43e8-9a55-f465109501c0.png)
可以看到，字段全部解析为 snake case. 但是该定义与 spring mvc 的请求参数映射逻辑不相符合。为了按照 snake case 获取对应的值，需要在 pojo 中设置特殊的 setter （带下划线，如 @LuoRenMu  先前的代码），或者通过获取所有参数 (Map<String,Object>) 后用 object mapper 进行重新转换（如本PR），代码都不简洁。

2. 如将 dto 标注为 `@ParameterObject` 则可以获得如下的参数解释：
![image](https://user-images.githubusercontent.com/8043546/229336670-123ff875-9eda-4900-9c46-5ddc898f89d5.png)
可以看到，与实际的映射逻辑（字段名直接映射）相符合，但是与现有的调用相冲突。并且，[ `@RequestParam`  无法应用于 field](https://github.com/spring-projects/spring-framework/issues/23618)  ，因此无法通过该注释修改接口参数名 。

现在有如下方案：
a. 使用原先的注解形式（即1），通过代码进行 case 转换。值得一提的是，该获取的参数解释并不合理，因为请求时根本就没有这样一个参数名 (commentsQueriesDTO)，可能会产生误导
b. 使用 `@ParameterObject` 注解并将以后的 api 接口参数转换为 camel case
c. 保持 snake case ，使用 `@RequestParam` 进行逐个映射并手动填入 dto 或通过通过工具转换

如果有其他的方案也提出来讨论一下。@dragove @LuoRenMu 
