### PR TITLE
实现评论置顶功能

### DIFF
--- a/src/main/java/plus/maa/backend/controller/CommentsAreaController.java
+++ b/src/main/java/plus/maa/backend/controller/CommentsAreaController.java
@@ -12,12 +12,9 @@ import org.springframework.web.bind.annotation.*;
 import plus.maa.backend.common.annotation.JsonSchema;
 import plus.maa.backend.config.SpringDocConfig;
 import plus.maa.backend.config.security.AuthenticationHelper;
-import plus.maa.backend.controller.request.comments.CommentsAddDTO;
-import plus.maa.backend.controller.request.comments.CommentsDeleteDTO;
-import plus.maa.backend.controller.request.comments.CommentsQueriesDTO;
-import plus.maa.backend.controller.request.comments.CommentsRatingDTO;
-import plus.maa.backend.controller.response.comments.CommentsAreaInfo;
+import plus.maa.backend.controller.request.comments.*;
 import plus.maa.backend.controller.response.MaaResult;
+import plus.maa.backend.controller.response.comments.CommentsAreaInfo;
 import plus.maa.backend.service.CommentsAreaService;
 
 /**
@@ -86,6 +83,18 @@ public class CommentsAreaController {
             @Parameter(description = "评论点赞对象") @Valid @RequestBody CommentsRatingDTO commentsRatingDTO
     ) {
         commentsAreaService.rates(authHelper.requireUserId(), commentsRatingDTO);
+        return MaaResult.success("成功");
+    }
+
+    @JsonSchema
+    @Operation(summary = "为评论置顶/取消置顶")
+    @ApiResponse(description = "置顶/取消置顶结果")
+    @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)
+    @PostMapping("/topping")
+    public MaaResult<String> toppingComments(
+            @Parameter(description = "评论置顶对象") @Valid @RequestBody CommentsToppingDTO commentsToppingDTO
+    ) {
+        commentsAreaService.topping(authHelper.requireUserId(), commentsToppingDTO);
         return MaaResult.success("成功");
     }
 

--- a/src/main/java/plus/maa/backend/controller/request/comments/CommentsToppingDTO.java
+++ b/src/main/java/plus/maa/backend/controller/request/comments/CommentsToppingDTO.java
@@ -1,0 +1,20 @@
+package plus.maa.backend.controller.request.comments;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Lixuhuilll
+ * Date  2023-08-17 11:20
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentsToppingDTO {
+    @NotBlank(message = "评论id不可为空")
+    private String commentId;
+    // 是否将指定评论置顶
+    private boolean topping = true;
+}

--- a/src/main/java/plus/maa/backend/controller/response/comments/CommentsInfo.java
+++ b/src/main/java/plus/maa/backend/controller/response/comments/CommentsInfo.java
@@ -27,5 +27,6 @@ public class CommentsInfo {
     private String message;
     private LocalDateTime uploadTime;
     private int like;
+    private boolean topping;
     private List<SubCommentsInfo> subCommentsInfos = new ArrayList<>();
 }

--- a/src/main/java/plus/maa/backend/repository/entity/CommentsArea.java
+++ b/src/main/java/plus/maa/backend/repository/entity/CommentsArea.java
@@ -42,6 +42,9 @@ public class CommentsArea implements Serializable {
 
     private LocalDateTime uploadTime = LocalDateTime.now();
 
+    // 是否将该评论置顶
+    private boolean topping;
+
     private boolean delete;
 
     private LocalDateTime deleteTime;


### PR DESCRIPTION
提供”/comments/topping“接口，通过该接口可设定是否置顶评论，只允许作业的作者置顶作业内的评论。
评论查询接口被修改为优先将置顶评论排在前面，并且评论查询接口返回的每条**主评论**将将带上”topping“字段，以向前端表明哪些**主评论**是置顶评论。