### PR TITLE
实现首页数据缓存以及入参 limit 限制为最大50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation 'com.github.erosb:everit-json-schema:1.14.2'
     implementation 'com.google.guava:guava:32.1.1-jre'
     implementation 'org.aspectj:aspectjweaver:1.9.19'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     swaggerCodegen 'org.openapitools:openapi-generator-cli:6.5.0'
 

--- a/src/main/java/plus/maa/backend/controller/CommentsAreaController.java
+++ b/src/main/java/plus/maa/backend/controller/CommentsAreaController.java
@@ -45,21 +45,8 @@ public class CommentsAreaController {
     @Operation(summary = "分页查询评论")
     @ApiResponse(description = "评论区信息")
     public MaaResult<CommentsAreaInfo> queriesCommentsArea(
-            @RequestParam(name = "copilotId") Long copilotId,
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
-            @RequestParam(name = "limit", required = false, defaultValue = "10") int limit,
-            @RequestParam(name = "desc", required = false, defaultValue = "true") boolean desc,
-            @RequestParam(name = "orderBy", required = false) String orderBy,
-            @RequestParam(name = "justSeeId", required = false) String justSeeId
+            @Parameter(description = "评论查询对象") @Valid CommentsQueriesDTO parsed
     ) {
-        var parsed = new CommentsQueriesDTO(
-                copilotId,
-                page,
-                limit,
-                desc,
-                orderBy,
-                justSeeId
-        );
         return MaaResult.success(commentsAreaService.queriesCommentsArea(parsed));
     }
 

--- a/src/main/java/plus/maa/backend/controller/CopilotController.java
+++ b/src/main/java/plus/maa/backend/controller/CopilotController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -14,9 +15,9 @@ import plus.maa.backend.config.security.AuthenticationHelper;
 import plus.maa.backend.controller.request.copilot.CopilotCUDRequest;
 import plus.maa.backend.controller.request.copilot.CopilotQueriesRequest;
 import plus.maa.backend.controller.request.copilot.CopilotRatingReq;
+import plus.maa.backend.controller.response.MaaResult;
 import plus.maa.backend.controller.response.copilot.CopilotInfo;
 import plus.maa.backend.controller.response.copilot.CopilotPageInfo;
-import plus.maa.backend.controller.response.MaaResult;
 import plus.maa.backend.service.CopilotService;
 
 /**
@@ -70,29 +71,8 @@ public class CopilotController {
     @ApiResponse(description = "作业信息")
     @GetMapping("/query")
     public MaaResult<CopilotPageInfo> queriesCopilot(
-            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
-            @RequestParam(name = "limit", required = false, defaultValue = "10") int limit,
-            @RequestParam(name = "level_keyword", required = false) String levelKeyword,
-            @RequestParam(name = "operator", required = false) String operator,
-            @RequestParam(name = "content", required = false) String content,
-            @RequestParam(name = "document", required = false) String document,
-            @RequestParam(name = "uploader_id", required = false) String uploaderId,
-            @RequestParam(name = "desc", required = false, defaultValue = "true") boolean desc,
-            @RequestParam(name = "order_by", required = false) String orderBy,
-            @RequestParam(name = "language", required = false) String language
+            @Parameter(description = "作业查询请求") @Valid CopilotQueriesRequest parsed
     ) {
-        var parsed = new CopilotQueriesRequest(
-                page,
-                limit,
-                levelKeyword,
-                operator,
-                content,
-                document,
-                uploaderId,
-                desc,
-                orderBy,
-                language
-        );
         return MaaResult.success(copilotService.queriesCopilot(helper.getUserId(), parsed));
     }
 

--- a/src/main/java/plus/maa/backend/controller/request/comments/CommentsQueriesDTO.java
+++ b/src/main/java/plus/maa/backend/controller/request/comments/CommentsQueriesDTO.java
@@ -1,5 +1,7 @@
 package plus.maa.backend.controller.request.comments;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,10 +16,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CommentsQueriesDTO {
+    @NotNull(message = "作业id不可为空")
     private Long copilotId;
-    private int page;
-    private int limit;
-    private boolean desc;
+    private int page = 0;
+    @Max(value = 50, message = "单页大小不得超过50")
+    private int limit = 10;
+    private boolean desc = true;
     private String orderBy;
     private String justSeeId;
 }

--- a/src/main/java/plus/maa/backend/controller/request/copilot/CopilotQueriesRequest.java
+++ b/src/main/java/plus/maa/backend/controller/request/copilot/CopilotQueriesRequest.java
@@ -1,25 +1,53 @@
 package plus.maa.backend.controller.request.copilot;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.Max;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * @author LoMu
  * Date  2022-12-26 2:48
  */
-@AllArgsConstructor
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class CopilotQueriesRequest {
-    private int page;
-    private int limit;
+    private int page = 0;
+    @Max(value = 50, message = "单页大小不得超过50")
+    private int limit = 10;
+    @JsonAlias("level_keyword")
     private String levelKeyword;
     private String operator;
     private String content;
     private String document;
+    @JsonAlias("uploader_id")
     private String uploaderId;
-    private boolean desc;
+    private boolean desc = true;
+    @JsonAlias("order_by")
     private String orderBy;
     private String language;
+
+    /*
+     * 这里为了正确接收前端的下划线风格，手动写了三个 setter 用于起别名
+     * 因为 Get 请求传入的参数不是 JSON，所以没办法使用 Jackson 的注解直接实现别名
+     * 添加 @JsonAlias 和 @JsonIgnore 注解只是为了保障 Swagger 的文档正确显示
+     * （吐槽一下，同样是Get请求，怎么CommentsQueries是驼峰命名，到了CopilotQueries就成了下划线命名）
+     */
+    @JsonIgnore
+    public void setLevel_keyword(String levelKeyword) {
+        this.levelKeyword = levelKeyword;
+    }
+
+    @JsonIgnore
+    public void setUploader_id(String uploaderId) {
+        this.uploaderId = uploaderId;
+    }
+
+    @JsonIgnore
+    public void setOrder_by(String orderBy) {
+        this.orderBy = orderBy;
+    }
 }
-
-

--- a/src/main/java/plus/maa/backend/controller/request/copilot/CopilotQueriesRequest.java
+++ b/src/main/java/plus/maa/backend/controller/request/copilot/CopilotQueriesRequest.java
@@ -1,6 +1,5 @@
 package plus.maa.backend.controller.request.copilot;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.Max;
 import lombok.AllArgsConstructor;
@@ -18,15 +17,12 @@ public class CopilotQueriesRequest {
     private int page = 0;
     @Max(value = 50, message = "单页大小不得超过50")
     private int limit = 10;
-    @JsonAlias("level_keyword")
     private String levelKeyword;
     private String operator;
     private String content;
     private String document;
-    @JsonAlias("uploader_id")
     private String uploaderId;
     private boolean desc = true;
-    @JsonAlias("order_by")
     private String orderBy;
     private String language;
 

--- a/src/main/java/plus/maa/backend/repository/RedisCache.java
+++ b/src/main/java/plus/maa/backend/repository/RedisCache.java
@@ -3,13 +3,20 @@ package plus.maa.backend.repository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -19,6 +26,7 @@ import java.util.function.Supplier;
  *
  * @author AnselYuki
  */
+@Slf4j
 @Setter
 @Component
 @RequiredArgsConstructor
@@ -27,6 +35,15 @@ public class RedisCache {
     private int expire;
 
     private final StringRedisTemplate redisTemplate;
+
+    //  添加 JSR310 模块，以便顺利序列化 LocalDateTime 等类型
+    private final ObjectMapper writeMapper = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .build();
+    private final ObjectMapper readMapper = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .build();
 
     public <T> void setData(final String key, T value) {
         setCache(key, value, 0, TimeUnit.SECONDS);
@@ -43,7 +60,7 @@ public class RedisCache {
     public <T> void setCache(final String key, T value, long timeout, TimeUnit timeUnit) {
         String json;
         try {
-            json = new ObjectMapper().writeValueAsString(value);
+            json = writeMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
             return;
         }
@@ -91,9 +108,9 @@ public class RedisCache {
                     return null;
                 }
             }
-            result = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).readValue(json, valueType);
+            result = readMapper.readValue(json, valueType);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             return null;
         }
         return result;
@@ -115,13 +132,13 @@ public class RedisCache {
                 if (StringUtils.isEmpty(json)) {
                     result = defaultValue;
                 } else {
-                    result = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).readValue(json, valueType);
+                    result = readMapper.readValue(json, valueType);
                 }
                 result = onUpdate.apply(result);
                 setCache(key, result, timeout, timeUnit);
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
         }
     }
 
@@ -135,5 +152,44 @@ public class RedisCache {
 
     public void removeCache(String key) {
         redisTemplate.delete(key);
+    }
+
+    /**
+     * 模糊删除缓存。
+     *
+     * @param pattern 待删除的 Key 表达式，例如 "home:*" 表示删除 Key 以 "home:" 开头的所有缓存
+     * @author Lixuhuilll
+     */
+    public void removeCacheByPattern(String pattern) {
+        // 批量删除的阈值
+        final int batchSize = 10000;
+        // 构造 ScanOptions
+        ScanOptions scanOptions = ScanOptions.scanOptions()
+                .count(batchSize)
+                .match(pattern)
+                .build();
+
+        // 保存要删除的键
+        List<String> keysToDelete = new ArrayList<>();
+
+        // try-with-resources 自动关闭 SCAN
+        try (Cursor<String> cursor = redisTemplate.scan(scanOptions)) {
+            while (cursor.hasNext()) {
+                String key = cursor.next();
+                // 将要删除的键添加到列表中
+                keysToDelete.add(key);
+
+                // 如果达到批量删除的阈值，则执行批量删除
+                if (keysToDelete.size() >= batchSize) {
+                    redisTemplate.delete(keysToDelete);
+                    keysToDelete.clear();
+                }
+            }
+        }
+
+        // 删除剩余的键（不足 batchSize 的最后一批）
+        if (!keysToDelete.isEmpty()) {
+            redisTemplate.delete(keysToDelete);
+        }
     }
 }

--- a/src/main/java/plus/maa/backend/repository/RedisCache.java
+++ b/src/main/java/plus/maa/backend/repository/RedisCache.java
@@ -101,16 +101,17 @@ public class RedisCache {
     }
 
     public <T> boolean valueMemberInSet(final String key, T value) {
-        String json;
         try {
-            json = writeMapper.writeValueAsString(value);
+            String json = writeMapper.writeValueAsString(value);
+            return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, json));
         } catch (JsonProcessingException e) {
             if (log.isDebugEnabled()) {
                 log.debug(e.getMessage(), e);
             }
-            return false;
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
         }
-        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, json));
+        return false;
     }
 
     public <T> T getCache(final String key, Class<T> valueType) {

--- a/src/main/java/plus/maa/backend/repository/RedisCache.java
+++ b/src/main/java/plus/maa/backend/repository/RedisCache.java
@@ -75,11 +75,11 @@ public class RedisCache {
         }
     }
 
-    public <T> void setTheSet(final String key, Collection<T> set, long timeout) {
-        setTheSet(key, set, timeout, TimeUnit.SECONDS);
+    public <T> void addSet(final String key, Collection<T> set, long timeout) {
+        addSet(key, set, timeout, TimeUnit.SECONDS);
     }
 
-    public <T> void setTheSet(final String key, Collection<T> set, long timeout, TimeUnit timeUnit) {
+    public <T> void addSet(final String key, Collection<T> set, long timeout, TimeUnit timeUnit) {
         String[] jsonList = new String[set.size()];
         try {
             int i = 0;

--- a/src/main/java/plus/maa/backend/service/CopilotService.java
+++ b/src/main/java/plus/maa/backend/service/CopilotService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -200,11 +201,19 @@ public class CopilotService {
 
     /**
      * 分页查询。传入 userId 不为空时限制为用户所有的数据
+     * 会缓存默认状态下热度和访问量排序的结果
      *
      * @param userId  获取已登录用户自己的作业数据
      * @param request 模糊查询
      * @return CopilotPageInfo
      */
+    @Cacheable(
+            cacheNames = "copilotPage",
+            key = "#request",
+            condition = "(#request.orderBy EQ 'hot' OR #request.orderBy EQ 'views')" +
+                    "AND #request.document == null AND #request.levelKeyword == null " +
+                    "AND #request.uploaderId == null AND #request.operator == null"
+    )
     public CopilotPageInfo queriesCopilot(@Nullable String userId, CopilotQueriesRequest request) {
         Sort.Order sortOrder = new Sort.Order(
                 request.isDesc() ? Sort.Direction.DESC : Sort.Direction.ASC,

--- a/src/main/java/plus/maa/backend/service/CopilotService.java
+++ b/src/main/java/plus/maa/backend/service/CopilotService.java
@@ -166,9 +166,11 @@ public class CopilotService {
              * 删除作业时，如果被删除的项在 Redis 首页缓存中存在，则清空首页缓存
              * 新增作业就不必，因为新作业显然不会那么快就登上热度榜和浏览量榜
              */
-            if (redisCache.valueMemberInSet("home:hot:copilotIds", copilot.getCopilotId())
-                    || redisCache.valueMemberInSet("home:copilotIds", copilot.getCopilotId())) {
-                redisCache.removeCacheByPattern("home:*");
+            if (redisCache.valueMemberInSet("home:hot:copilotIds", copilot.getCopilotId())) {
+                redisCache.removeCacheByPattern("home:hot:*");
+            }
+            if (redisCache.valueMemberInSet("home:views:copilotIds", copilot.getCopilotId())) {
+                redisCache.removeCacheByPattern("home:views:*");
             }
         });
     }

--- a/src/main/java/plus/maa/backend/service/CopilotService.java
+++ b/src/main/java/plus/maa/backend/service/CopilotService.java
@@ -358,10 +358,10 @@ public class CopilotService {
             if ("hot".equals(request.getOrderBy())) {
                 // 热度榜缓存一天
                 timout = 3600 * 24;
-                redisCache.setTheSet("home:hot:copilotIds", copilotIds, timout);
+                redisCache.addSet("home:hot:copilotIds", copilotIds, timout);
             } else {
                 // 其他均保持默认
-                redisCache.setTheSet("home:copilotIds", copilotIds, timout);
+                redisCache.addSet("home:copilotIds", copilotIds, timout);
             }
             redisCache.setCache(cacheKey.get(), data, timout);
         }

--- a/src/main/java/plus/maa/backend/task/CopilotScoreRefreshTask.java
+++ b/src/main/java/plus/maa/backend/task/CopilotScoreRefreshTask.java
@@ -7,6 +7,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import plus.maa.backend.repository.CopilotRatingRepository;
 import plus.maa.backend.repository.CopilotRepository;
+import plus.maa.backend.repository.RedisCache;
 import plus.maa.backend.repository.entity.Copilot;
 import plus.maa.backend.repository.entity.CopilotRating;
 import plus.maa.backend.service.CopilotService;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class CopilotScoreRefreshTask {
 
+    RedisCache redisCache;
     CopilotRepository copilotRepository;
     CopilotRatingRepository copilotRatingRepository;
 
@@ -48,6 +50,8 @@ public class CopilotScoreRefreshTask {
             changedCopilots.add(copilot);
         }
         copilotRepository.saveAll(changedCopilots);
+        // 移除首页热度缓存
+        redisCache.removeCacheByPattern("home:hot:*");
     }
 
 }


### PR DESCRIPTION
"/copilot/query"接口添加首页数据缓存
"/copilot/query"接口和"/comments/query"接口入参 limit 限制为最多 50
实现了Issue #121 的前两项功能