### PR TITLE
修复找回密码时，未正常处理验证码匹配失败产生的跨线程异常

### DIFF
--- a/src/main/java/plus/maa/backend/service/EmailService.java
+++ b/src/main/java/plus/maa/backend/service/EmailService.java
@@ -14,6 +14,7 @@ import org.springframework.util.Assert;
 import plus.maa.backend.common.bo.EmailBusinessObject;
 import plus.maa.backend.config.external.MaaCopilotProperties;
 import plus.maa.backend.config.external.Mail;
+import plus.maa.backend.controller.response.MaaResultException;
 import plus.maa.backend.repository.RedisCache;
 import plus.maa.backend.service.model.CommentNotification;
 
@@ -87,10 +88,17 @@ public class EmailService {
         redisCache.setCache("vCodeEmail:" + email, vcode, expire);
     }
 
-    @Async
+    /**
+     * 检验验证码并抛出异常
+     * @param email 邮箱
+     * @param vcode 验证码
+     * @throws MaaResultException 验证码错误
+     */
     public void verifyVCode(String email, String vcode) {
         String cacheVCode = redisCache.getCache("vCodeEmail:" + email, String.class);
-        Assert.state(StringUtils.equalsIgnoreCase(cacheVCode, vcode), "验证码错误");
+        if (!StringUtils.equalsIgnoreCase(cacheVCode, vcode)) {
+            throw new MaaResultException(401, "验证码错误");
+        }
         redisCache.removeCache("vCodeEmail:" + email);
     }
 


### PR DESCRIPTION
在修 https://github.com/MaaAssistantArknights/maa-copilot-frontend/pull/192 也就是 #119 这个bug时发现：

在新线程中若验证码错误会直接assert抛出异常，web线程不会捕获到该异常，结果就是response一直为200

![image](https://github.com/MaaAssistantArknights/MaaBackendCenter/assets/25633151/da6e1141-6b6b-48aa-aa33-a263f4e7b91a)

--------

于是把异步的注解删了
