### PR TITLE
实现作业隐藏功能。拆分作业上传、更新、删除对象，使得Swagger UI的接口文档更清晰准确。

### DIFF
--- a/src/main/java/plus/maa/backend/common/aop/JsonSchemaAop.java
+++ b/src/main/java/plus/maa/backend/common/aop/JsonSchemaAop.java
@@ -19,7 +19,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import plus.maa.backend.common.annotation.JsonSchema;
 import plus.maa.backend.controller.request.comments.CommentsRatingDTO;
-import plus.maa.backend.controller.request.copilot.CopilotCUDRequest;
+import plus.maa.backend.controller.request.copilot.CopilotAddRequest;
+import plus.maa.backend.controller.request.copilot.CopilotUpdateRequest;
 import plus.maa.backend.controller.request.copilot.CopilotRatingReq;
 import plus.maa.backend.controller.response.MaaResultException;
 
@@ -57,8 +58,12 @@ public class JsonSchemaAop {
         String content = null;
         //判断是验证的是Copilot还是Rating
         for (Object arg : joinPoint.getArgs()) {
-            if (arg instanceof CopilotCUDRequest) {
-                content = ((CopilotCUDRequest) arg).getContent();
+            if (arg instanceof CopilotAddRequest addRequest) {
+                content = addRequest.getContent();
+                schema_json = COPILOT_SCHEMA_JSON;
+            }
+            if (arg instanceof CopilotUpdateRequest updateRequest) {
+                content = updateRequest.getContent();
                 schema_json = COPILOT_SCHEMA_JSON;
             }
             if (arg instanceof CopilotRatingReq || arg instanceof CommentsRatingDTO) {

--- a/src/main/java/plus/maa/backend/common/utils/converter/CopilotConverter.java
+++ b/src/main/java/plus/maa/backend/common/utils/converter/CopilotConverter.java
@@ -38,7 +38,7 @@ public interface CopilotConverter {
     @Mapping(target = "ratingRatio", ignore = true)
     @Mapping(target = "ratingLevel", ignore = true)
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-    void updateCopilotFromDto(CopilotDTO copilotDTO, String content, @MappingTarget Copilot copilot);
+    void updateCopilotFromDto(CopilotDTO copilotDTO, String content, boolean hidden, @MappingTarget Copilot copilot);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "deleteTime", ignore = true)
@@ -52,13 +52,14 @@ public interface CopilotConverter {
     @Mapping(target = "uploadTime", source = "now")
     @Mapping(target = "firstUploadTime", source = "now")
     @Mapping(target = "uploaderId", source = "userId")
-    Copilot toCopilot(CopilotDTO copilotDto, String userId, LocalDateTime now, Long copilotId, String content);
+    Copilot toCopilot(CopilotDTO copilotDto, String userId, LocalDateTime now, Long copilotId, String content, boolean hidden);
 
     @Mapping(target = "ratingType", ignore = true)
     @Mapping(target = "ratingRatio", ignore = true)
     @Mapping(target = "ratingLevel", ignore = true)
     @Mapping(target = "notEnoughRating", ignore = true)
     @Mapping(target = "available", ignore = true)
+    @Mapping(target = "hidden", ignore = true)
     @Mapping(target = "id", source = "copilotId")
     @Mapping(target = "uploader", source = "userName")
     @Mapping(target = "like", source = "copilot.likeCount")

--- a/src/main/java/plus/maa/backend/controller/CommentsAreaController.java
+++ b/src/main/java/plus/maa/backend/controller/CommentsAreaController.java
@@ -73,7 +73,6 @@ public class CommentsAreaController {
         return MaaResult.success("成功");
     }
 
-    @JsonSchema
     @Operation(summary = "为评论置顶/取消置顶")
     @ApiResponse(description = "置顶/取消置顶结果")
     @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)

--- a/src/main/java/plus/maa/backend/controller/CopilotController.java
+++ b/src/main/java/plus/maa/backend/controller/CopilotController.java
@@ -12,9 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import plus.maa.backend.common.annotation.JsonSchema;
 import plus.maa.backend.config.SpringDocConfig;
 import plus.maa.backend.config.security.AuthenticationHelper;
-import plus.maa.backend.controller.request.copilot.CopilotCUDRequest;
-import plus.maa.backend.controller.request.copilot.CopilotQueriesRequest;
-import plus.maa.backend.controller.request.copilot.CopilotRatingReq;
+import plus.maa.backend.controller.request.copilot.*;
 import plus.maa.backend.controller.response.MaaResult;
 import plus.maa.backend.controller.response.copilot.CopilotInfo;
 import plus.maa.backend.controller.response.copilot.CopilotPageInfo;
@@ -39,9 +37,9 @@ public class CopilotController {
     @JsonSchema
     @PostMapping("/upload")
     public MaaResult<Long> uploadCopilot(
-            @Parameter(description = "作业操作请求") @RequestBody CopilotCUDRequest request
+            @Parameter(description = "作业操作请求") @RequestBody CopilotAddRequest request
     ) {
-        return MaaResult.success(copilotService.upload(helper.requireUserId(), request.getContent()));
+        return MaaResult.success(copilotService.upload(helper.requireUserId(), request));
     }
 
     @Operation(summary = "删除作业")
@@ -49,7 +47,7 @@ public class CopilotController {
     @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)
     @PostMapping("/delete")
     public MaaResult<Void> deleteCopilot(
-            @Parameter(description = "作业操作请求") @RequestBody CopilotCUDRequest request
+            @Parameter(description = "作业操作请求") @RequestBody CopilotDeleteRequest request
     ) {
         copilotService.delete(helper.requireUserId(), request);
         return MaaResult.success();
@@ -82,9 +80,9 @@ public class CopilotController {
     @JsonSchema
     @PostMapping("/update")
     public MaaResult<Void> updateCopilot(
-            @Parameter(description = "作业操作请求") @RequestBody CopilotCUDRequest copilotCUDRequest
+            @Parameter(description = "作业操作请求") @RequestBody CopilotUpdateRequest copilotUpdateRequest
     ) {
-        copilotService.update(helper.requireUserId(), copilotCUDRequest);
+        copilotService.update(helper.requireUserId(), copilotUpdateRequest);
         return MaaResult.success();
     }
 

--- a/src/main/java/plus/maa/backend/controller/request/copilot/CopilotAddRequest.java
+++ b/src/main/java/plus/maa/backend/controller/request/copilot/CopilotAddRequest.java
@@ -1,0 +1,20 @@
+package plus.maa.backend.controller.request.copilot;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 作业创建请求
+ *
+ * @author lixuhuilll
+ * Date 2023-08-23 17:50
+ */
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CopilotAddRequest {
+    private String content;
+    private boolean hidden = false; // 是否隐藏作业
+}

--- a/src/main/java/plus/maa/backend/controller/request/copilot/CopilotDeleteRequest.java
+++ b/src/main/java/plus/maa/backend/controller/request/copilot/CopilotDeleteRequest.java
@@ -1,0 +1,19 @@
+package plus.maa.backend.controller.request.copilot;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 作业删除请求
+ *
+ * @author lixuhuilll
+ * Date 2023-08-23 17:50
+ */
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CopilotDeleteRequest {
+    private Long id;
+}

--- a/src/main/java/plus/maa/backend/controller/request/copilot/CopilotUpdateRequest.java
+++ b/src/main/java/plus/maa/backend/controller/request/copilot/CopilotUpdateRequest.java
@@ -7,7 +7,8 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class CopilotCUDRequest {
+public class CopilotUpdateRequest {
     private String content;
+    private boolean hidden = false; // 是否隐藏作业
     private Long id;
 }

--- a/src/main/java/plus/maa/backend/controller/response/copilot/CopilotInfo.java
+++ b/src/main/java/plus/maa/backend/controller/response/copilot/CopilotInfo.java
@@ -1,5 +1,6 @@
 package plus.maa.backend.controller.response.copilot;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,4 +28,6 @@ public class CopilotInfo implements Serializable {
     private String content;
     private long like;
     private long dislike;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean hidden = null;  // 一般情况下不会返回这个字段，只有在查看自己的作业详情时才会返回
 }

--- a/src/main/java/plus/maa/backend/repository/entity/Copilot.java
+++ b/src/main/java/plus/maa/backend/repository/entity/Copilot.java
@@ -78,6 +78,9 @@ public class Copilot implements Serializable {
     // 原始数据
     private String content;
 
+    // 是否隐藏作业
+    private boolean hidden = false;
+
     @JsonIgnore
     private boolean delete;
     @JsonIgnore


### PR DESCRIPTION
按照前端的需求https://github.com/MaaAssistantArknights/maa-copilot-frontend/issues/197
实现了作业隐藏功能，当 copilot/query 查询的条件不是 me 时，不会返回隐藏的作业。
作业中新增 hidden 字段，只有当作业作者进入自己作业的详情时，才会传回该字段。
copilot/upload 和 copilot/update 接口可接收 hidden 字段，如未传入该字段则默认为 false。
优化了Swagger UI的相关接口文档。