### PR TITLE
接入MAA Account

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/plus/maa/backend/config/security/AuthenticationHelper.java
+++ b/src/main/java/plus/maa/backend/config/security/AuthenticationHelper.java
@@ -49,7 +49,7 @@ public class AuthenticationHelper {
 
 
     /**
-     * 获取MAA Account用户的邮箱及用户名(用于未注册)
+     *  获取MAA Account用户的邮箱及用户名(用于未注册)
      */
     public @NotNull MaaUser getUserNameAndEmail() {
         var principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/main/java/plus/maa/backend/config/security/AuthenticationHelper.java
+++ b/src/main/java/plus/maa/backend/config/security/AuthenticationHelper.java
@@ -6,14 +6,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.server.ResponseStatusException;
 import plus.maa.backend.common.utils.IpUtil;
+import plus.maa.backend.controller.response.MaaResultException;
+import plus.maa.backend.repository.entity.MaaUser;
 import plus.maa.backend.service.jwt.JwtAuthToken;
 import plus.maa.backend.service.model.LoginUser;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -41,6 +45,24 @@ public class AuthenticationHelper {
         if (id == null)
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         return id;
+    }
+
+
+    /**
+     * 获取MAA Account用户的邮箱及用户名(用于未注册)
+     */
+    public @NotNull MaaUser getUserNameAndEmail() {
+        var principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal == null) {
+            throw new MaaResultException("账户未登录");
+        }
+        if (principal instanceof OAuth2User) {
+            Map<String, Object> attributes = ((OAuth2User) principal).getAttributes();
+            var email = attributes.get("email").toString();
+            var nickname = attributes.get("nickname").toString();
+            return new MaaUser().setUserName(nickname).setEmail(email);
+        }
+        return (MaaUser) principal;
     }
 
     /**

--- a/src/main/java/plus/maa/backend/config/security/SecurityConfig.java
+++ b/src/main/java/plus/maa/backend/config/security/SecurityConfig.java
@@ -1,16 +1,18 @@
 package plus.maa.backend.config.security;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import plus.maa.backend.config.external.MaaCopilotProperties;
+
+import java.io.PrintWriter;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -18,6 +20,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
  * @author AnselYuki
  */
 @Configuration
+@Slf4j
 @RequiredArgsConstructor
 public class SecurityConfig {
     /**
@@ -26,7 +29,9 @@ public class SecurityConfig {
     private static final String[] URL_WHITELIST = {
             "/user/login",
             "/user/register",
-            "/user/sendRegistrationToken"
+            "/user/sendRegistrationToken",
+            "/user/login/maa",
+            "/login/oauth2/code/maa"
     };
 
     private static final String[] URL_PERMIT_ALL = {
@@ -70,6 +75,7 @@ public class SecurityConfig {
     private final JwtAuthenticationTokenFilter jwtAuthenticationTokenFilter;
     private final AuthenticationEntryPointImpl authenticationEntryPoint;
     private final AccessDeniedHandlerImpl accessDeniedHandler;
+    private final MaaCopilotProperties maaCopilotProperties;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -83,10 +89,6 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        //关闭CSRF,设置无状态连接
-        http.csrf(AbstractHttpConfigurer::disable)
-                //不通过Session获取SecurityContext
-                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         //允许匿名访问的接口，如果是测试想要方便点就把这段全注释掉
         http.authorizeHttpRequests(authorize ->
@@ -106,6 +108,24 @@ public class SecurityConfig {
 
         //开启跨域请求
         http.cors(withDefaults());
+
+        http.oauth2Login(o -> o.loginPage("/user")
+                .authorizationEndpoint(authorizationEndpointConfig -> authorizationEndpointConfig
+                        .baseUri("/user/login"))
+                .defaultSuccessUrl(maaCopilotProperties.getInfo().getFrontendDomain())
+               );
+
+        //授权失败(正常来说不可能触发)
+        http.oauth2Login(o -> o
+                .failureHandler((request, response, exception) -> {
+            PrintWriter writer = response.getWriter();
+            writer.println(exception.getMessage());
+            log.warn(exception.getMessage());
+        }));
+
+
+
         return http.build();
     }
+
 }

--- a/src/main/java/plus/maa/backend/config/security/SecurityConfig.java
+++ b/src/main/java/plus/maa/backend/config/security/SecurityConfig.java
@@ -9,8 +9,8 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -39,8 +39,6 @@ public class SecurityConfig {
      * 添加放行接口在此处
      */
     private static final String[] URL_WHITELIST = {
-            "/user/login",
-            "/user/register",
             "/user/sendRegistrationToken",
             "/user/login/maa",
             "/login/oauth2/code/maa"
@@ -65,6 +63,11 @@ public class SecurityConfig {
             "/file/upload",
             "/comments/status",
             "/copilot/status"
+
+    };
+
+    private static final String[] URL_AUTHENTICATION_0 = {
+            "/user/login"
     };
 
     //添加需要权限1才能访问的接口
@@ -90,10 +93,6 @@ public class SecurityConfig {
     private final MaaCopilotProperties maaCopilotProperties;
     private final UserRepository userRepository;
 
-    @Bean
-    public BCryptPasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 
     @Bean
     public AuthenticationManager authenticationManager() throws Exception {
@@ -109,6 +108,7 @@ public class SecurityConfig {
                         .requestMatchers(URL_PERMIT_ALL).permitAll()
                         //权限 0 未激活 1 激活  等等.. (拥有权限1必然拥有权限0 拥有权限2必然拥有权限1、0)
                         //指定接口需要指定权限才能访问 如果不开启RBAC注释掉这一段即可
+                        .requestMatchers(URL_AUTHENTICATION_0).hasAuthority("0")
                         .requestMatchers(URL_AUTHENTICATION_1).hasAuthority("1")
                         //此处用于管理员操作接口
                         .requestMatchers(URL_AUTHENTICATION_2).hasAuthority("2")
@@ -166,6 +166,7 @@ public class SecurityConfig {
                             throw new MaaResultException(MaaStatusCode.MAA_USER_EXISTS);
                         }
                     }
+                    mappedAuthorities.add(new SimpleGrantedAuthority(Integer.toString(0)));
                 }
             });
 

--- a/src/main/java/plus/maa/backend/config/security/SecurityConfig.java
+++ b/src/main/java/plus/maa/backend/config/security/SecurityConfig.java
@@ -123,8 +123,6 @@ public class SecurityConfig {
             log.warn(exception.getMessage());
         }));
 
-
-
         return http.build();
     }
 

--- a/src/main/java/plus/maa/backend/controller/UserController.java
+++ b/src/main/java/plus/maa/backend/controller/UserController.java
@@ -5,24 +5,24 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import plus.maa.backend.config.SpringDocConfig;
 import plus.maa.backend.config.external.MaaCopilotProperties;
 import plus.maa.backend.config.security.AuthenticationHelper;
-import plus.maa.backend.controller.request.user.*;
-import plus.maa.backend.controller.response.user.MaaLoginRsp;
+import plus.maa.backend.controller.request.user.RefreshReq;
+import plus.maa.backend.controller.request.user.UserInfoUpdateDTO;
 import plus.maa.backend.controller.response.MaaResult;
-import plus.maa.backend.controller.response.user.MaaUserInfo;
+import plus.maa.backend.controller.response.user.MaaLoginRsp;
 import plus.maa.backend.service.EmailService;
 import plus.maa.backend.service.UserService;
-
-import java.io.IOException;
 
 /**
  * 用户相关接口
@@ -45,55 +45,7 @@ public class UserController {
     @Value("${maa-copilot.jwt.header}")
     private String header;
 
-    /**
-     * 激活token中的用户
-     *
-     * @param activateDTO 激活码
-     * @return 成功响应
-     */
-    @Operation(summary = "激活用户")
-    @ApiResponse(description = "激活用户结果")
-    @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)
-    @PostMapping("/activate")
-    public MaaResult<Void> activate(
-            @Parameter(description = "激活用户请求") @Valid @RequestBody ActivateDTO activateDTO
-    ) {
-        // FIXME 应改为从 body 中获取， 解决激活——登录悖论，待讨论
-        var userId = helper.requireUserId();
-        userService.activateUser(userId, activateDTO);
-        return MaaResult.success();
-    }
 
-    /**
-     * 注册完成后发送邮箱激活码
-     *
-     * @return null
-     */
-    @Operation(summary = "完成注册后发送邮箱激活码")
-    @ApiResponse(description = "激活码发送结果")
-    @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)
-    @PostMapping("/activate/request")
-    public MaaResult<Void> activateRequest() {
-        // FIXME 完成注册后发送激活码不应该由客户端请求
-        userService.sendActiveCodeByEmail(helper.requireUserId());
-        return MaaResult.success();
-    }
-
-    /**
-     * 更新当前用户的密码(根据原密码)
-     *
-     * @return http响应
-     */
-    @Operation(summary = "修改当前用户密码", description = "根据原密码")
-    @ApiResponse(description = "修改密码结果")
-    @SecurityRequirement(name = SpringDocConfig.SECURITY_SCHEME_NAME)
-    @PostMapping("/update/password")
-    public MaaResult<Void> updatePassword(
-            @Parameter(description = "修改密码请求") @RequestBody @Valid PasswordUpdateDTO updateDTO
-    ) {
-        userService.modifyPassword(helper.requireUserId(), updateDTO.getNewPassword());
-        return MaaResult.success();
-    }
 
     /**
      * 更新用户详细信息
@@ -112,37 +64,7 @@ public class UserController {
         return MaaResult.success();
     }
 
-    /**
-     * 邮箱重设密码
-     *
-     * @param passwordResetDTO 通过邮箱修改密码请求
-     * @return 成功响应
-     */
-    @PostMapping("/password/reset")
-    @Operation(summary = "重置密码")
-    @ApiResponse(description = "重置密码结果")
-    public MaaResult<Void> passwordReset(@Parameter(description = "重置密码请求") @RequestBody @Valid PasswordResetDTO passwordResetDTO) {
-        // 校验用户邮箱是否存在
-        userService.checkUserExistByEmail(passwordResetDTO.getEmail());
-        userService.modifyPasswordByActiveCode(passwordResetDTO);
-        return MaaResult.success();
-    }
 
-    /**
-     * 验证码重置密码功能：
-     * 发送验证码用于重置
-     *
-     * @return 成功响应
-     */
-    @PostMapping("/password/reset_request")
-    @Operation(summary = "发送用于重置密码的验证码")
-    @ApiResponse(description = "验证码发送结果")
-    public MaaResult<Void> passwordResetRequest(@Parameter(description = "发送重置密码的验证码请求") @RequestBody @Valid PasswordResetVCodeDTO passwordResetVCodeDTO) {
-        // 校验用户邮箱是否存在
-        userService.checkUserExistByEmail(passwordResetVCodeDTO.getEmail());
-        emailService.sendVCode(passwordResetVCodeDTO.getEmail());
-        return MaaResult.success();
-    }
 
     /**
      * 刷新token
@@ -158,56 +80,18 @@ public class UserController {
         return MaaResult.success(res);
     }
 
-    /**
-     * 用户注册
-     *
-     * @param user 传入用户参数
-     * @return 注册成功用户信息摘要
-     */
-    @PostMapping("/register")
-    @Operation(summary = "用户注册")
-    @ApiResponse(description = "注册结果")
-    public MaaResult<MaaUserInfo> register(@Parameter(description = "用户注册请求") @Valid @RequestBody RegisterDTO user) {
-        return MaaResult.success(userService.register(user));
-    }
 
     /**
-     * 获得注册时的验证码
-     */
-    @PostMapping("/sendRegistrationToken")
-    @Operation(summary = "注册时发送验证码")
-    @ApiResponse(description = "发送验证码结果", responseCode = "204")
-    public MaaResult<Void> sendRegistrationToken(@Parameter(description = "发送注册验证码请求") @RequestBody SendRegistrationTokenDTO regDTO) {
-        //FIXME: 增加频率限制或者 captcha
-        emailService.sendVCode(regDTO.getEmail());
-        return new MaaResult<>(204, null, null);
-    }
-
-    /**
-     * 用户登录
+     *  授权用户登录
      *
-     * @param user 登录参数
      * @return 成功响应，荷载JwtToken
      */
     @PostMapping("/login")
     @Operation(summary = "用户登录")
     @ApiResponse(description = "登录结果")
-    public MaaResult<MaaLoginRsp> login(@Parameter(description = "登录请求") @RequestBody @Valid LoginDTO user) {
-        return MaaResult.success("登陆成功", userService.login(user));
+    public MaaResult<MaaLoginRsp> login() {
+        return MaaResult.success("登陆成功", userService.login(helper.getUserNameAndEmail()));
     }
 
-    @GetMapping("/activateAccount")
-    @Operation(summary = "激活账号")
-    @ApiResponse(description = "激活账号结果")
-    public MaaResult<Void> activateAccount(@Parameter(description = "激活请求") EmailActivateReq activateDTO,
-                                           @Parameter(description = "页面跳转参数") HttpServletResponse response) {
-        userService.activateAccount(activateDTO);
-        // 激活成功 跳转页面
-        try {
-            response.sendRedirect(properties.getInfo().getFrontendDomain());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return MaaResult.success();
-    }
+
 }

--- a/src/main/java/plus/maa/backend/controller/UserController.java
+++ b/src/main/java/plus/maa/backend/controller/UserController.java
@@ -10,10 +10,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import plus.maa.backend.config.SpringDocConfig;
 import plus.maa.backend.config.external.MaaCopilotProperties;
 import plus.maa.backend.config.security.AuthenticationHelper;
@@ -86,7 +83,7 @@ public class UserController {
      *
      * @return 成功响应，荷载JwtToken
      */
-    @PostMapping("/login")
+    @GetMapping("/login")
     @Operation(summary = "用户登录")
     @ApiResponse(description = "登录结果")
     public MaaResult<MaaLoginRsp> login() {

--- a/src/main/java/plus/maa/backend/repository/UserRepository.java
+++ b/src/main/java/plus/maa/backend/repository/UserRepository.java
@@ -5,6 +5,7 @@ import plus.maa.backend.repository.entity.MaaUser;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -18,7 +19,7 @@ public interface UserRepository extends MongoRepository<MaaUser, String> {
      * @param email 邮箱字段
      * @return 查询用户
      */
-    MaaUser findByEmail(String email);
+    Optional<MaaUser> findByEmail(String email);
 
     default Map<String, MaaUser> findByUsersId(List<String> userId) {
         return findAllById(userId)

--- a/src/main/java/plus/maa/backend/service/UserDetailServiceImpl.java
+++ b/src/main/java/plus/maa/backend/service/UserDetailServiceImpl.java
@@ -31,14 +31,13 @@ public class UserDetailServiceImpl implements UserDetailsService {
      */
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        MaaUser user = userRepository.findByEmail(email);
-        if (user == null) {
+        var user = userRepository.findByEmail(email);
+        if (user.isEmpty()) {
             throw new UsernameNotFoundException("用户不存在");
         }
-
-        var permissions = collectAuthoritiesFor(user);
+        var permissions = collectAuthoritiesFor(user.get());
         //数据封装成UserDetails返回
-        return new LoginUser(user, permissions);
+        return new LoginUser(user.get(), permissions);
     }
 
     public Collection<? extends GrantedAuthority> collectAuthoritiesFor(MaaUser user) {

--- a/src/main/java/plus/maa/backend/service/UserDetailServiceImpl.java
+++ b/src/main/java/plus/maa/backend/service/UserDetailServiceImpl.java
@@ -40,7 +40,7 @@ public class UserDetailServiceImpl implements UserDetailsService {
         return new LoginUser(user.get(), permissions);
     }
 
-    public Collection<? extends GrantedAuthority> collectAuthoritiesFor(MaaUser user) {
+    public static Collection<? extends GrantedAuthority> collectAuthoritiesFor(MaaUser user) {
         var authorities = new ArrayList<GrantedAuthority>();
         for (int i = 0; i <= user.getStatus(); i++) {
             authorities.add(new SimpleGrantedAuthority(Integer.toString(i)));

--- a/src/main/java/plus/maa/backend/service/UserService.java
+++ b/src/main/java/plus/maa/backend/service/UserService.java
@@ -1,30 +1,23 @@
 package plus.maa.backend.service;
 
-import cn.hutool.core.lang.Assert;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.BeanUtils;
 import org.springframework.dao.DuplicateKeyException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import plus.maa.backend.common.MaaStatusCode;
 import plus.maa.backend.common.utils.converter.MaaUserConverter;
-import plus.maa.backend.controller.request.user.*;
+import plus.maa.backend.controller.request.user.UserInfoUpdateDTO;
 import plus.maa.backend.controller.response.MaaResultException;
 import plus.maa.backend.controller.response.user.MaaLoginRsp;
-import plus.maa.backend.controller.response.user.MaaUserInfo;
-import plus.maa.backend.repository.RedisCache;
 import plus.maa.backend.repository.UserRepository;
 import plus.maa.backend.repository.entity.MaaUser;
 import plus.maa.backend.service.jwt.JwtExpiredException;
 import plus.maa.backend.service.jwt.JwtInvalidException;
 import plus.maa.backend.service.jwt.JwtService;
 
-import java.util.ArrayList;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -39,26 +32,34 @@ public class UserService {
     // 未来转为配置项
     private static final int LOGIN_LIMIT = 1;
 
-    private final RedisCache redisCache;
     private final UserRepository userRepository;
-    private final EmailService emailService;
-    private final PasswordEncoder passwordEncoder;
     private final UserDetailServiceImpl userDetailService;
     private final JwtService jwtService;
     private final MaaUserConverter maaUserConverter;
 
     /**
-     * 登录方法
+     * 授权登录 签发本地服务器令牌
      *
-     * @param loginDTO 登录参数
+     * @param  maaUser MAA Account 邮箱/用户名
      * @return 携带了token的封装类
      */
-    public MaaLoginRsp login(LoginDTO loginDTO) {
-        var user = userRepository.findByEmail(loginDTO.getEmail());
-        if (user == null || !passwordEncoder.matches(loginDTO.getPassword(), user.getPassword())) {
-            throw new MaaResultException(401, "用户不存在或者密码错误");
+    public MaaLoginRsp login(MaaUser maaUser) {
+        var userOptional = userRepository.findByEmail(maaUser.getEmail());
+        if (userOptional.isEmpty()) {
+            maaUser.setStatus(1);
+            try {
+                userRepository.save(maaUser);
+                userOptional = userRepository.findByEmail(maaUser.getEmail());
+            } catch (DuplicateKeyException e) {
+                throw new MaaResultException(MaaStatusCode.MAA_USER_EXISTS);
+            }
         }
 
+        if (userOptional.isEmpty()) {
+            throw new RuntimeException(":(");
+        }
+
+        var user = userOptional.get();
         var jwtId = UUID.randomUUID().toString();
         var jwtIds = user.getRefreshJwtIds();
         jwtIds.add(jwtId);
@@ -80,63 +81,7 @@ public class UserService {
         );
     }
 
-    /**
-     * 修改密码
-     *
-     * @param userId      当前用户
-     * @param rawPassword 新密码
-     */
-    public void modifyPassword(String userId, String rawPassword) {
-        var userResult = userRepository.findById(userId);
-        if (userResult.isEmpty()) return;
-        var maaUser = userResult.get();
-        // 修改密码的逻辑，应当使用与 authentication provider 一致的编码器
-        maaUser.setPassword(passwordEncoder.encode(rawPassword));
-        maaUser.setRefreshJwtIds(new ArrayList<>());
-        userRepository.save(maaUser);
-    }
 
-    /**
-     * 用户注册
-     *
-     * @param registerDTO 传入用户参数
-     * @return 返回注册成功的用户摘要（脱敏）
-     */
-    public MaaUserInfo register(RegisterDTO registerDTO) {
-        String encode = passwordEncoder.encode(registerDTO.getPassword());
-
-        MaaUser user = new MaaUser();
-        BeanUtils.copyProperties(registerDTO, user);
-        user.setPassword(encode);
-        user.setStatus(1);
-        MaaUserInfo userInfo;
-        if (!emailService.verifyVCode2(user.getEmail(), registerDTO.getRegistrationToken(), false)) {
-            throw new MaaResultException(MaaStatusCode.MAA_REGISTRATION_CODE_NOT_FOUND);
-        }
-        try {
-            MaaUser save = userRepository.save(user);
-            userInfo = new MaaUserInfo(save);
-        } catch (DuplicateKeyException e) {
-            throw new MaaResultException(MaaStatusCode.MAA_USER_EXISTS);
-        }
-        return userInfo;
-    }
-
-    /**
-     * 通过传入的JwtToken来获取当前用户的信息
-     *
-     * @param userId      当前用户
-     * @param activateDTO 邮箱激活码
-     */
-    public void activateUser(@NotNull String userId, ActivateDTO activateDTO) {
-        userRepository.findById(userId).ifPresent((maaUser) -> {
-            if (1 == maaUser.getStatus()) return;
-            var email = maaUser.getEmail();
-            emailService.verifyVCode(email, activateDTO.getToken());
-            maaUser.setStatus(1);
-            userRepository.save(maaUser);
-        });
-    }
 
     /**
      * 更新用户信息
@@ -151,18 +96,6 @@ public class UserService {
         });
     }
 
-    /**
-     * 为用户发送激活验证码
-     *
-     * @param userId 用户 id
-     */
-    public void sendActiveCodeByEmail(String userId) {
-        userRepository.findById(userId).ifPresent((maaUser) -> {
-            Assert.state(Objects.equals(maaUser.getStatus(), 0),
-                    "用户已经激活，无法再次发送验证码");
-            emailService.sendVCode(maaUser.getEmail());
-        });
-    }
 
     /**
      * 刷新token
@@ -204,52 +137,9 @@ public class UserService {
         }
     }
 
-    /**
-     * 通过邮箱激活码更新密码
-     *
-     * @param passwordResetDTO 通过邮箱修改密码请求
-     */
-    public void modifyPasswordByActiveCode(PasswordResetDTO passwordResetDTO) {
-        emailService.verifyVCode(passwordResetDTO.getEmail(), passwordResetDTO.getActiveCode());
-        var maaUser = userRepository.findByEmail(passwordResetDTO.getEmail());
-        modifyPassword(maaUser.getUserId(), passwordResetDTO.getPassword());
-    }
 
-    /**
-     * 根据邮箱校验用户是否存在
-     *
-     * @param email 用户邮箱
-     */
-    public void checkUserExistByEmail(String email) {
-        if (null == userRepository.findByEmail(email)) {
-            throw new MaaResultException(MaaStatusCode.MAA_USER_NOT_FOUND);
-        }
-    }
 
-    /**
-     * 激活账户
-     *
-     * @param activateDTO uuid
-     */
-    public void activateAccount(EmailActivateReq activateDTO) {
-        String uuid = activateDTO.getNonce();
-        String email = redisCache.getCache("UUID:" + uuid, String.class);
-        Assert.notNull(email, "链接已过期");
-        MaaUser user = userRepository.findByEmail(email);
 
-        try {
-            if (Objects.equals(user.getStatus(), 1)) {
-                return;
-            }
-            // 激活账户
-            user.setStatus(1);
-            userRepository.save(user);
-
-            // 清除缓存
-        } finally {
-            redisCache.removeCache("UUID:" + uuid);
-        }
-    }
 
 
 }

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -17,7 +17,7 @@ spring:
           maa:
             client-id: $I_Am_The_Bone_Of_My_Sword!Steel_Is_My_Body_And_Fire_Is_My_Blood!$
             client-secret: $I_Am_The_Bone_Of_My_Sword!Steel_Is_My_Body_And_Fire_Is_My_Blood!$
-            redirect-uri: https://${maa-copilot.info.domain}/login/oauth2/code/maa
+            redirect-uri: ${maa-copilot.info.domain}/login/oauth2/code/maa
             authorization-grant-type: authorization_code
         provider:
           maa:

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -6,11 +6,25 @@ spring:
       # uri: mongodb://localhost:27017/MaaBackend
       # 有密码
       # uri: mongodb://用户名:密码@localhost:27017/MaaBackend
-      uri: mongodb://localhost/MaaBackend
+      uri: mongodb://192.168.1.104/MaaBackend
     redis:
       port: 6379
-      host: localhost
-
+      host: 192.168.1.104
+  security:
+    oauth2:
+      client:
+        registration:
+          maa:
+            client-id: $I_Am_The_Bone_Of_My_Sword!Steel_Is_My_Body_And_Fire_Is_My_Blood!$
+            client-secret: $I_Am_The_Bone_Of_My_Sword!Steel_Is_My_Body_And_Fire_Is_My_Blood!$
+            redirect-uri: https://${maa-copilot.info.domain}/login/oauth2/code/maa
+            authorization-grant-type: authorization_code
+        provider:
+          maa:
+            user-name-attribute: email
+            authorization-uri: https://hub.maa-org.net/application/o/authorize/
+            token-uri: https://hub.maa-org.net/application/o/token/
+            user-info-uri: https://hub.maa-org.net/application/o/userinfo/
 maa-copilot:
   backup:
     dir: /home/dove/copilotBak
@@ -60,8 +74,6 @@ maa-copilot:
     ssl: false
     #邮件通知
     notification: true
-
-
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
Spring Security OAuth2 我用的也挺迷的 官方文档我翻了半天也没咋看的太懂    
    
它授权成功后会直接将授权服务器的UserInfo存入Spring Security上下文    

/user/login/maa 为授权登录

/login/oauth2/code/maa 回调接口

暂时将授权成功后跳转的地址设置成了
```java
defaultSuccessUrl(maaCopilotProperties.getInfo().getFrontendDomain())
```
 
暂时将0标志为授权成功 访问/user/login接口获取本地服务器的Token令牌 

代码没做太大改变  

如果用户不存在 会直接通过授权服务器的用户信息创建账户       

移除了原登录接口     