### PR TITLE
Add HTTP Etag Cache

### DIFF
--- a/src/main/java/plus/maa/backend/MainApplication.java
+++ b/src/main/java/plus/maa/backend/MainApplication.java
@@ -3,6 +3,7 @@ package plus.maa.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -17,6 +18,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableMethodSecurity
+@ServletComponentScan
 public class MainApplication {
     public static void main(String[] args) {
         SpringApplication.run(MainApplication.class, args);

--- a/src/main/java/plus/maa/backend/controller/CopilotController.java
+++ b/src/main/java/plus/maa/backend/controller/CopilotController.java
@@ -79,7 +79,7 @@ public class CopilotController {
             @Parameter(description = "作业查询请求") @Valid CopilotQueriesRequest parsed
     ) {
         // 两秒防抖，缓解前端重复请求问题
-        response.setHeader(HttpHeaders.CACHE_CONTROL, "max-age=2, must-revalidate");
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "private, max-age=2, must-revalidate");
         return MaaResult.success(copilotService.queriesCopilot(helper.getUserId(), parsed));
     }
 

--- a/src/main/java/plus/maa/backend/controller/CopilotController.java
+++ b/src/main/java/plus/maa/backend/controller/CopilotController.java
@@ -5,9 +5,11 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 import plus.maa.backend.common.annotation.JsonSchema;
 import plus.maa.backend.common.annotation.SensitiveWordDetection;
@@ -33,6 +35,7 @@ import plus.maa.backend.service.CopilotService;
 public class CopilotController {
     private final CopilotService copilotService;
     private final AuthenticationHelper helper;
+    private final HttpServletResponse response;
 
     @Operation(summary = "上传作业")
     @ApiResponse(description = "上传作业结果")
@@ -75,6 +78,8 @@ public class CopilotController {
     public MaaResult<CopilotPageInfo> queriesCopilot(
             @Parameter(description = "作业查询请求") @Valid CopilotQueriesRequest parsed
     ) {
+        // 两秒防抖，缓解前端重复请求问题
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "max-age=2, must-revalidate");
         return MaaResult.success(copilotService.queriesCopilot(helper.getUserId(), parsed));
     }
 

--- a/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
+++ b/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
@@ -1,0 +1,55 @@
+package plus.maa.backend.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+import plus.maa.backend.repository.RedisCache;
+
+import java.io.IOException;
+
+
+/**
+ * 提供基于 Etag 机制的 HTTP 缓存，有助于降低网络传输的压力
+ *
+ * @author lixuhuilll
+ */
+
+// 配置需要使用 Etag 机制的 URL，注意和 Spring 的 UrlPattern 语法不太一样
+@WebFilter(urlPatterns = {
+        "/arknights/level",
+        "/copilot/query",
+        "/copilot/get/*"
+})
+@RequiredArgsConstructor
+public class MaaEtagHeaderFilter extends ShallowEtagHeaderFilter {
+
+    private final RedisCache redisCache;
+
+    @Override
+    protected void doFilterInternal(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull FilterChain filterChain) throws ServletException, IOException {
+        // 允许使用 Etag （实际是避免默认添加的 no-store）
+        response.setHeader("Cache-Control", "no-cache, max-age=0, must-revalidate");
+        // 为 ArkLevel 进行特殊处理，因为它在 Redis 中存在指示变更的值，可以借此节约性能
+        if ("/arknights/level".equals(request.getRequestURI())) {
+            String levelCommit = redisCache.getCacheLevelCommit();
+            levelCommit = levelCommit == null ? "0" : levelCommit;
+            WebRequest webRequest = new ServletWebRequest(request, response);
+            if (webRequest.checkNotModified(levelCommit)) {
+                // 只要 Redis 中指示的 levelCommit 未变更，则认为可以使用浏览器缓存的地图数据
+                return;
+            }
+            // levelCommit 发生变更或当前用户不存在缓存，响应新数据
+            filterChain.doFilter(request, response);
+            return;
+        }
+        // 其他接口默认处理即可
+        super.doFilterInternal(request, response, filterChain);
+    }
+}

--- a/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
+++ b/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
@@ -7,10 +7,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.web.context.request.ServletWebRequest;
-import org.springframework.web.context.request.WebRequest;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
-import plus.maa.backend.repository.RedisCache;
 
 import java.io.IOException;
 
@@ -29,25 +27,15 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class MaaEtagHeaderFilter extends ShallowEtagHeaderFilter {
 
-    private final RedisCache redisCache;
-
     @Override
     protected void doFilterInternal(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull FilterChain filterChain) throws ServletException, IOException {
-        // 允许使用 Etag （实际是避免默认添加的 no-store）
-        response.setHeader("Cache-Control", "no-cache, max-age=0, must-revalidate");
-        // 为 ArkLevel 进行特殊处理，因为它在 Redis 中存在指示变更的值，可以借此节约性能
-        if ("/arknights/level".equals(request.getRequestURI())) {
-            String levelCommit = redisCache.getCacheLevelCommit();
-            levelCommit = levelCommit == null ? "0" : levelCommit;
-            WebRequest webRequest = new ServletWebRequest(request, response);
-            if (webRequest.checkNotModified(levelCommit)) {
-                // 只要 Redis 中指示的 levelCommit 未变更，则认为可以使用浏览器缓存的地图数据
-                return;
-            }
-            // levelCommit 发生变更或当前用户不存在缓存，响应新数据
+        if (!HttpMethod.GET.matches(request.getMethod())) {
+            // ETag 只处理安全的请求
             filterChain.doFilter(request, response);
             return;
         }
+        // 允许使用 Etag （实际是避免默认添加的 no-store）
+        response.setHeader("Cache-Control", "no-cache, max-age=0, must-revalidate");
         // 其他接口默认处理即可，注意默认操作相当于牺牲 CPU 来节约网络带宽，不适用于结果变更过快的接口
         super.doFilterInternal(request, response, filterChain);
     }

--- a/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
+++ b/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
@@ -24,8 +24,7 @@ import java.io.IOException;
 // 配置需要使用 Etag 机制的 URL，注意和 Spring 的 UrlPattern 语法不太一样
 @WebFilter(urlPatterns = {
         "/arknights/level",
-        "/copilot/query",
-        "/copilot/get/*"
+        "/copilot/query"
 })
 @RequiredArgsConstructor
 public class MaaEtagHeaderFilter extends ShallowEtagHeaderFilter {

--- a/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
+++ b/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
@@ -49,7 +49,7 @@ public class MaaEtagHeaderFilter extends ShallowEtagHeaderFilter {
             filterChain.doFilter(request, response);
             return;
         }
-        // 其他接口默认处理即可
+        // 其他接口默认处理即可，注意默认操作相当于牺牲 CPU 来节约网络带宽，不适用于结果变更过快的接口
         super.doFilterInternal(request, response, filterChain);
     }
 }

--- a/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
+++ b/src/main/java/plus/maa/backend/filter/MaaEtagHeaderFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
@@ -35,7 +36,7 @@ public class MaaEtagHeaderFilter extends ShallowEtagHeaderFilter {
             return;
         }
         // 允许使用 Etag （实际是避免默认添加的 no-store）
-        response.setHeader("Cache-Control", "no-cache, max-age=0, must-revalidate");
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache, max-age=0, must-revalidate");
         // 其他接口默认处理即可，注意默认操作相当于牺牲 CPU 来节约网络带宽，不适用于结果变更过快的接口
         super.doFilterInternal(request, response, filterChain);
     }


### PR DESCRIPTION
启用部分数据体积较大的接口的 HTTP Etag 机制，节约服务器带宽，此过程浏览器会自动处理，对前端是透明的，无需前端适配。