### PR TITLE
ci: use PAT for pushing commits to maa-copilot-client-ts

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -121,11 +121,13 @@ jobs:
           body: https://github.com/MaaAssistantArknights/MaaBackendCenter/actions/runs/${{ github.run_id }}
           branch: ts-client
           delete-branch: true
+          token: ${{ secrets.TS_CLIENT_PAT }}
 
       - name: Tag previous commit with version
         if: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           cd maa-copilot-client-ts
+          git remote set-url origin https://${{ secrets.TS_CLIENT_PAT }}@github.com/MaaAssistantArknights/maa-copilot-client-ts.git
           git checkout ts-client
           git tag ${{ steps.version.outputs.version }}
           git push --tags


### PR DESCRIPTION
需要先设置 `TS_CLIENT_PAT`