### PR TITLE
ci: fix PAT conflicting with default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -105,6 +105,7 @@ jobs:
         with:
           repository: MaaAssistantArknights/maa-copilot-client-ts
           path: maa-copilot-client-ts
+          token: ${{ secrets.TS_CLIENT_PAT }}
 
       - name: Copy ts client into maa-copilot-client-ts
         run: |
@@ -127,7 +128,6 @@ jobs:
         if: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           cd maa-copilot-client-ts
-          git remote set-url origin https://${{ secrets.TS_CLIENT_PAT }}@github.com/MaaAssistantArknights/maa-copilot-client-ts.git
           git checkout ts-client
           git tag ${{ steps.version.outputs.version }}
           git push --tags


### PR DESCRIPTION
貌似 PAT 应该在 checkout 的时候就设置进去，不然会使用默认的 `GITHUB_TOKEN`，和 PAT 冲突