### PR TITLE
fix: 修复无法获取活动关卡开放状态的问题

### DIFF
--- a/src/main/kotlin/plus/maa/backend/repository/entity/gamedata/MaaArkStage.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/entity/gamedata/MaaArkStage.kt
@@ -1,7 +1,11 @@
 package plus.maa.backend.repository.entity.gamedata
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.LowerCamelCaseStrategy
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 
+// 小驼峰
+@JsonNaming(LowerCamelCaseStrategy::class)
 // 忽略对服务器无用的数据
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class MaaArkStage(


### PR DESCRIPTION
经本地测试，当前线上代码无法抓取活动关卡的开放状态，原因是注入的 ObjectMapper 默认使用 SNAKE_CASE 命名方式