### PR TITLE
feat: add user fuzzy search

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,9 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
     swaggerCodegen("org.openapitools:openapi-generator-cli:7.10.0")
+
+    implementation("com.belerweb:pinyin4j:2.5.0")
+    implementation("com.github.houbb:opencc4j:1.8.1")
 }
 
 val swaggerOutputDir = layout.buildDirectory.dir("docs")

--- a/src/main/kotlin/plus/maa/backend/common/utils/PinyinUtil.kt
+++ b/src/main/kotlin/plus/maa/backend/common/utils/PinyinUtil.kt
@@ -31,11 +31,7 @@ object PinyinUtil {
         val sb = StringBuilder()
         input.forEach { ch ->
             val pinyinArray = PinyinHelper.toHanyuPinyinStringArray(ch)
-            if (pinyinArray != null && pinyinArray.isNotEmpty()) {
-                sb.append(pinyinArray[0][0])
-            } else {
-                sb.append(pinyinArray?.firstOrNull()?.get(0) ?: ch)
-            }
+            sb.append(pinyinArray?.firstOrNull()?.get(0) ?: ch)
         }
         return sb.toString()
     }

--- a/src/main/kotlin/plus/maa/backend/common/utils/PinyinUtil.kt
+++ b/src/main/kotlin/plus/maa/backend/common/utils/PinyinUtil.kt
@@ -6,6 +6,7 @@ import net.sourceforge.pinyin4j.format.HanyuPinyinOutputFormat
 import net.sourceforge.pinyin4j.format.HanyuPinyinToneType
 import net.sourceforge.pinyin4j.format.HanyuPinyinVCharType
 
+@Suppress("unused")
 object PinyinUtil {
     private val format = HanyuPinyinOutputFormat().apply {
         caseType = HanyuPinyinCaseType.LOWERCASE
@@ -17,7 +18,7 @@ object PinyinUtil {
         val sb = StringBuilder()
         input.forEach { ch ->
             val pinyinArray = PinyinHelper.toHanyuPinyinStringArray(ch, format)
-            if (pinyinArray != null && pinyinArray.isNotEmpty()) {
+            if (!pinyinArray.isNullOrEmpty()) {
                 sb.append(pinyinArray[0])
             } else {
                 sb.append(ch)
@@ -33,7 +34,7 @@ object PinyinUtil {
             if (pinyinArray != null && pinyinArray.isNotEmpty()) {
                 sb.append(pinyinArray[0][0])
             } else {
-                sb.append(ch)
+                sb.append(pinyinArray?.firstOrNull()?.get(0) ?: ch)
             }
         }
         return sb.toString()

--- a/src/main/kotlin/plus/maa/backend/common/utils/PinyinUtil.kt
+++ b/src/main/kotlin/plus/maa/backend/common/utils/PinyinUtil.kt
@@ -1,0 +1,41 @@
+package plus.maa.backend.common.utils
+
+import net.sourceforge.pinyin4j.PinyinHelper
+import net.sourceforge.pinyin4j.format.HanyuPinyinCaseType
+import net.sourceforge.pinyin4j.format.HanyuPinyinOutputFormat
+import net.sourceforge.pinyin4j.format.HanyuPinyinToneType
+import net.sourceforge.pinyin4j.format.HanyuPinyinVCharType
+
+object PinyinUtil {
+    private val format = HanyuPinyinOutputFormat().apply {
+        caseType = HanyuPinyinCaseType.LOWERCASE
+        toneType = HanyuPinyinToneType.WITHOUT_TONE
+        vCharType = HanyuPinyinVCharType.WITH_V
+    }
+
+    fun pinyinFull(input: String): String {
+        val sb = StringBuilder()
+        input.forEach { ch ->
+            val pinyinArray = PinyinHelper.toHanyuPinyinStringArray(ch, format)
+            if (pinyinArray != null && pinyinArray.isNotEmpty()) {
+                sb.append(pinyinArray[0])
+            } else {
+                sb.append(ch)
+            }
+        }
+        return sb.toString()
+    }
+
+    fun pinyinAbbr(input: String): String {
+        val sb = StringBuilder()
+        input.forEach { ch ->
+            val pinyinArray = PinyinHelper.toHanyuPinyinStringArray(ch)
+            if (pinyinArray != null && pinyinArray.isNotEmpty()) {
+                sb.append(pinyinArray[0][0])
+            } else {
+                sb.append(ch)
+            }
+        }
+        return sb.toString()
+    }
+}

--- a/src/main/kotlin/plus/maa/backend/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/plus/maa/backend/config/security/SecurityConfig.kt
@@ -107,8 +107,7 @@ class SecurityConfig(
                 "/copilot/rating",
                 "/comments/query",
                 "/file/upload",
-                "/comments/status",
-                "/copilot/status",
+                "/copilot/ban",
             )
 
         // 添加需要权限1才能访问的接口
@@ -117,8 +116,10 @@ class SecurityConfig(
                 "/copilot/delete",
                 "/copilot/update",
                 "/copilot/upload",
+                "/copilot/status",
                 "/comments/add",
                 "/comments/delete",
+                "/comments/status",
             )
 
         private val URL_AUTHENTICATION_2 =

--- a/src/main/kotlin/plus/maa/backend/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/plus/maa/backend/config/security/SecurityConfig.kt
@@ -91,6 +91,7 @@ class SecurityConfig(
                 "/error",
                 "/version",
                 "/user/info",
+                "/user/search",
                 "/user/activateAccount",
                 "/user/password/reset_request",
                 "/user/password/reset",

--- a/src/main/kotlin/plus/maa/backend/controller/CopilotController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/CopilotController.kt
@@ -102,12 +102,11 @@ class CopilotController(
         return success("success")
     }
 
-
     @Operation(summary = "禁用评论区/开启评论区")
     @RequireJwt
-    @PostMapping("/ban")
-    fun banComments(@RequestParam coplitId: @NotBlank Long, @RequestParam status: CommentStatus): MaaResult<String> {
-        copilotService.commentStatus(helper.requireUserId(), coplitId, status)
+    @GetMapping("/ban")
+    fun banComments(@RequestParam copilotId: @NotBlank Long, @RequestParam status: CommentStatus): MaaResult<String> {
+        copilotService.commentStatus(helper.requireUserId(), copilotId, status)
         return success("success")
     }
 }

--- a/src/main/kotlin/plus/maa/backend/controller/CopilotController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/CopilotController.kt
@@ -27,6 +27,7 @@ import plus.maa.backend.controller.response.MaaResult.Companion.success
 import plus.maa.backend.controller.response.copilot.CopilotInfo
 import plus.maa.backend.controller.response.copilot.CopilotPageInfo
 import plus.maa.backend.service.CopilotService
+import plus.maa.backend.service.model.CommentStatus
 
 /**
  * @author LoMu
@@ -97,7 +98,16 @@ class CopilotController(
     @ApiResponse(description = "success")
     @GetMapping("/status")
     fun modifyStatus(@RequestParam id: @NotBlank Long, @RequestParam status: Boolean): MaaResult<String> {
-        copilotService.notificationStatus(helper.obtainUserId(), id, status)
+        copilotService.notificationStatus(helper.requireUserId(), id, status)
+        return success("success")
+    }
+
+
+    @Operation(summary = "禁用评论区/开启评论区")
+    @RequireJwt
+    @PostMapping("/ban")
+    fun banComments(@RequestParam coplitId: @NotBlank Long, @RequestParam status: CommentStatus): MaaResult<String> {
+        copilotService.commentStatus(helper.requireUserId(), coplitId, status)
         return success("success")
     }
 }

--- a/src/main/kotlin/plus/maa/backend/controller/UserController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/UserController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -172,5 +173,9 @@ class UserController(
     @GetMapping("/search")
     @Operation(summary = "用户模糊搜索")
     @ApiResponse(description = "模糊搜索匹配结果")
-    fun searchUsers(@RequestParam userName: String): MaaResult<List<MaaUserInfo>> = success(userService.search(userName))
+    fun searchUsers(@RequestParam userName: String, @RequestParam page: Int, @RequestParam size: Int): MaaResult<List<MaaUserInfo>> {
+        val pageable = PageRequest.of(page, size)
+        val resultPage = userService.search(userName, pageable)
+        return success(resultPage.content)
+    }
 }

--- a/src/main/kotlin/plus/maa/backend/controller/UserController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/UserController.kt
@@ -158,4 +158,12 @@ class UserController(
     @Operation(summary = "查询用户信息")
     @ApiResponse(description = "用户详情信息")
     fun getUserInfo(@RequestParam userId: String): MaaResult<MaaUserInfo> = success(userService.get(userId))
+
+    /**
+     * 用户模糊搜索
+     */
+    @GetMapping("/search")
+    @Operation(summary = "用户模糊搜索")
+    @ApiResponse(description = "模糊搜索匹配结果")
+    fun searchUsers(@RequestParam userName: String): MaaResult<List<MaaUserInfo>> = success(userService.search(userName))
 }

--- a/src/main/kotlin/plus/maa/backend/controller/UserController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/UserController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
@@ -173,8 +174,12 @@ class UserController(
     @GetMapping("/search")
     @Operation(summary = "用户模糊搜索")
     @ApiResponse(description = "模糊搜索匹配结果")
-    fun searchUsers(@RequestParam userName: String, @RequestParam page: Int, @RequestParam size: Int): MaaResult<List<MaaUserInfo>> {
-        val pageable = PageRequest.of(page, size)
+    fun searchUsers(
+        @RequestParam userName: String,
+        @RequestParam page: Int = 1,
+        @Max(50, message = "查询用户量不能超过50") @RequestParam size: Int = 10,
+    ): MaaResult<List<MaaUserInfo>> {
+        val pageable = PageRequest.of(page - 1, size)
         val resultPage = userService.search(userName, pageable)
         return success(resultPage.content)
     }

--- a/src/main/kotlin/plus/maa/backend/controller/request/comments/CommentsAddDTO.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/request/comments/CommentsAddDTO.kt
@@ -32,5 +32,5 @@ data class CommentsAddDTO(
     /**
      * 是否允许评论
      */
-    val commentStatus: CommentStatus = CommentStatus.ENABLED
+    val commentStatus: CommentStatus = CommentStatus.ENABLED,
 )

--- a/src/main/kotlin/plus/maa/backend/controller/request/comments/CommentsAddDTO.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/request/comments/CommentsAddDTO.kt
@@ -2,6 +2,7 @@ package plus.maa.backend.controller.request.comments
 
 import jakarta.validation.constraints.NotBlank
 import org.hibernate.validator.constraints.Length
+import plus.maa.backend.service.model.CommentStatus
 
 /**
  * @author LoMu
@@ -28,4 +29,8 @@ data class CommentsAddDTO(
      * 是否接收通知
      */
     val notification: Boolean = true,
+    /**
+     * 是否允许评论
+     */
+    val commentStatus: CommentStatus = CommentStatus.ENABLED
 )

--- a/src/main/kotlin/plus/maa/backend/controller/response/copilot/CopilotInfo.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/response/copilot/CopilotInfo.kt
@@ -1,5 +1,6 @@
 package plus.maa.backend.controller.response.copilot
 
+import plus.maa.backend.service.model.CommentStatus
 import java.io.Serializable
 import java.time.LocalDateTime
 
@@ -20,4 +21,5 @@ data class CopilotInfo(
     val content: String,
     val like: Long = 0,
     val dislike: Long = 0,
+    val commentStatus: CommentStatus =  CommentStatus.ENABLED,
 ) : Serializable

--- a/src/main/kotlin/plus/maa/backend/controller/response/copilot/CopilotInfo.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/response/copilot/CopilotInfo.kt
@@ -21,5 +21,5 @@ data class CopilotInfo(
     val content: String,
     val like: Long = 0,
     val dislike: Long = 0,
-    val commentStatus: CommentStatus =  CommentStatus.ENABLED,
+    val commentStatus: CommentStatus = CommentStatus.ENABLED,
 ) : Serializable

--- a/src/main/kotlin/plus/maa/backend/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/plus/maa/backend/handler/GlobalExceptionHandler.kt
@@ -2,6 +2,7 @@ package plus.maa.backend.handler
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.ConstraintViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.AuthenticationException
 import org.springframework.web.HttpRequestMethodNotSupportedException
@@ -108,7 +109,7 @@ class GlobalExceptionHandler {
     /**
      * 处理由 [org.springframework.util.Assert] 工具产生的异常
      */
-    @ExceptionHandler(IllegalArgumentException::class, IllegalStateException::class)
+    @ExceptionHandler(IllegalArgumentException::class, IllegalStateException::class, ConstraintViolationException::class)
     fun illegalArgumentOrStateExceptionHandler(e: RuntimeException): MaaResult<Unit> {
         return fail(HttpStatus.BAD_REQUEST.value(), e.message)
     }

--- a/src/main/kotlin/plus/maa/backend/repository/UserRepository.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/UserRepository.kt
@@ -19,8 +19,6 @@ interface UserRepository : MongoRepository<MaaUser, String> {
 
     fun findByUserId(userId: String): MaaUser?
 
-    @Query("{'\$or': [ " +
-        "{ 'userName': { \$eq: ?0 } }, " +
-        "] }")
+    @Query("{ 'userName': { '\$regex': ?0, '\$options': 'i' } }")
     fun searchUsers(userName: String): List<MaaUserInfo>
 }

--- a/src/main/kotlin/plus/maa/backend/repository/UserRepository.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/UserRepository.kt
@@ -1,6 +1,8 @@
 package plus.maa.backend.repository
 
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.mongodb.repository.Query
+import plus.maa.backend.controller.response.user.MaaUserInfo
 import plus.maa.backend.repository.entity.MaaUser
 
 /**
@@ -16,4 +18,9 @@ interface UserRepository : MongoRepository<MaaUser, String> {
     fun findByEmail(email: String): MaaUser?
 
     fun findByUserId(userId: String): MaaUser?
+
+    @Query("{'\$or': [ " +
+        "{ 'userName': { \$eq: ?0 } }, " +
+        "] }")
+    fun searchUsers(userName: String): List<MaaUserInfo>
 }

--- a/src/main/kotlin/plus/maa/backend/repository/UserRepository.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/UserRepository.kt
@@ -1,5 +1,7 @@
 package plus.maa.backend.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.repository.MongoRepository
 import org.springframework.data.mongodb.repository.Query
 import plus.maa.backend.controller.response.user.MaaUserInfo
@@ -19,6 +21,6 @@ interface UserRepository : MongoRepository<MaaUser, String> {
 
     fun findByUserId(userId: String): MaaUser?
 
-    @Query("{ 'userName': { '\$regex': ?0, '\$options': 'i' } }")
-    fun searchUsers(userName: String): List<MaaUserInfo>
+    @Query("{ 'userName': { '\$regex': ?0, '\$options': 'i' }, 'status': 1 }")
+    fun searchUsers(userName: String, pageable: Pageable): Page<MaaUserInfo>
 }

--- a/src/main/kotlin/plus/maa/backend/repository/entity/Copilot.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/entity/Copilot.kt
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.Transient
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
+import plus.maa.backend.service.model.CommentStatus
 import java.io.Serializable
 import java.time.LocalDateTime
 
@@ -55,6 +56,8 @@ class Copilot(
     var uploadTime: LocalDateTime? = null,
     // 原始数据
     var content: String? = null,
+    @JsonIgnore
+    var commentStatus: CommentStatus? = CommentStatus.ENABLED,
     @JsonIgnore
     var delete: Boolean = false,
     @JsonIgnore

--- a/src/main/kotlin/plus/maa/backend/service/CommentsAreaService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CommentsAreaService.kt
@@ -96,7 +96,7 @@ class CommentsAreaService(
             targetMsg,
             replier.userName,
             message,
-            "?op=${copilot.copilotId}"
+            "?op=${copilot.copilotId}",
         )
     }
 

--- a/src/main/kotlin/plus/maa/backend/service/CommentsAreaService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CommentsAreaService.kt
@@ -15,6 +15,7 @@ import plus.maa.backend.controller.request.comments.CommentsAddDTO
 import plus.maa.backend.controller.request.comments.CommentsQueriesDTO
 import plus.maa.backend.controller.request.comments.CommentsRatingDTO
 import plus.maa.backend.controller.request.comments.CommentsToppingDTO
+import plus.maa.backend.controller.response.MaaResultException
 import plus.maa.backend.controller.response.comments.CommentsAreaInfo
 import plus.maa.backend.controller.response.comments.CommentsInfo
 import plus.maa.backend.controller.response.comments.SubCommentsInfo
@@ -23,6 +24,7 @@ import plus.maa.backend.repository.CopilotRepository
 import plus.maa.backend.repository.entity.CommentsArea
 import plus.maa.backend.repository.entity.Copilot
 import plus.maa.backend.repository.entity.MaaUser
+import plus.maa.backend.service.model.CommentStatus
 import plus.maa.backend.service.model.RatingType
 import plus.maa.backend.service.sensitiveword.SensitiveWordService
 import java.time.LocalDateTime
@@ -52,6 +54,11 @@ class CommentsAreaService(
         sensitiveWordService.validate(commentsAddDTO.message)
         val copilotId = commentsAddDTO.copilotId
         val copilot = copilotRepository.findByCopilotId(copilotId).requireNotNull { "作业不存在" }
+
+        if (copilot.commentStatus == CommentStatus.DISABLED && userId != copilot.uploaderId) {
+            throw MaaResultException("评论区已被禁用")
+        }
+
         if (userId != copilot.uploaderId) {
             require(commentsAddDTO.message.length <= 150) { "评论内容不可超过150字，请删减" }
         }

--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -33,6 +33,7 @@ import plus.maa.backend.repository.entity.Copilot
 import plus.maa.backend.repository.entity.Copilot.OperationGroup
 import plus.maa.backend.repository.entity.Rating
 import plus.maa.backend.service.level.ArkLevelService
+import plus.maa.backend.service.model.CommentStatus
 import plus.maa.backend.service.model.CopilotSetStatus
 import plus.maa.backend.service.model.RatingCache
 import plus.maa.backend.service.model.RatingType
@@ -457,14 +458,13 @@ class CopilotService(
     }
 
     fun commentStatus(userId: String?, copilotId: Long, status: CommentStatus) {
-        val copilotOptional = copilotRepository.findByCopilotId(copilotId)
-        Assert.isTrue(copilotOptional != null, "copilot不存在")
-        val copilot = copilotOptional!!
+        val copilot = copilotRepository.findByCopilotId(copilotId)
+        checkNotNull(copilot) { "copilot不存在" }
         Assert.isTrue(userId == copilot.uploaderId, "您没有权限修改")
         copilot.commentStatus = status
         copilotRepository.save(copilot)
     }
-    
+
     /**
      * 用于重置缓存，数据修改为私有或者删除时用于重置缓存防止继续被查询到
      */

--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -463,6 +463,15 @@ class CopilotService(
         copilotRepository.save(copilot)
     }
 
+    fun commentStatus(userId: String?, copilotId: Long, status: CommentStatus) {
+        val copilotOptional = copilotRepository.findByCopilotId(copilotId)
+        Assert.isTrue(copilotOptional != null, "copilot不存在")
+        val copilot = copilotOptional!!
+        Assert.isTrue(userId == copilot.uploaderId, "您没有权限修改")
+        copilot.commentStatus = status
+        copilotRepository.save(copilot)
+    }
+
     companion object {
         /*
         首页分页查询缓存配置
@@ -497,14 +506,5 @@ class CopilotService(
             val order = ln(max(s, 1.0))
             return order + s / 1000.0 + base
         }
-    }
-
-    fun commentStatus(userId: String, coplitId: Long, status: CommentStatus) {
-        val copilotOptional = copilotRepository.findByCopilotId(coplitId)
-        Assert.isTrue(copilotOptional != null, "copilot不存在")
-        val copilot = copilotOptional!!
-        Assert.isTrue(userId == copilot.uploaderId, "您没有权限修改")
-        copilot.commentStatus = status
-        copilotRepository.save(copilot)
     }
 }

--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -33,6 +33,7 @@ import plus.maa.backend.repository.entity.Copilot
 import plus.maa.backend.repository.entity.Copilot.OperationGroup
 import plus.maa.backend.repository.entity.Rating
 import plus.maa.backend.service.level.ArkLevelService
+import plus.maa.backend.service.model.CommentStatus
 import plus.maa.backend.service.model.RatingCache
 import plus.maa.backend.service.model.RatingType
 import plus.maa.backend.service.sensitiveword.SensitiveWordService
@@ -496,5 +497,14 @@ class CopilotService(
             val order = ln(max(s, 1.0))
             return order + s / 1000.0 + base
         }
+    }
+
+    fun commentStatus(userId: String, coplitId: Long, status: CommentStatus) {
+        val copilotOptional = copilotRepository.findByCopilotId(coplitId)
+        Assert.isTrue(copilotOptional != null, "copilot不存在")
+        val copilot = copilotOptional!!
+        Assert.isTrue(userId == copilot.uploaderId, "您没有权限修改")
+        copilot.commentStatus = status
+        copilotRepository.save(copilot)
     }
 }

--- a/src/main/kotlin/plus/maa/backend/service/UserService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/UserService.kt
@@ -5,6 +5,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import plus.maa.backend.common.MaaStatusCode
+import plus.maa.backend.common.utils.PinyinUtil
 import plus.maa.backend.controller.request.user.LoginDTO
 import plus.maa.backend.controller.request.user.PasswordResetDTO
 import plus.maa.backend.controller.request.user.RegisterDTO
@@ -20,6 +21,7 @@ import plus.maa.backend.service.jwt.JwtInvalidException
 import plus.maa.backend.service.jwt.JwtService
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import com.github.houbb.opencc4j.util.ZhConverterUtil
 
 /**
  * @author AnselYuki
@@ -222,4 +224,24 @@ class UserService(
     }
 
     fun get(userId: String): MaaUserInfo = (userRepository.findByUserId(userId) ?: MaaUser.UNKNOWN).run(::MaaUserInfo)
+
+    /**
+     * 用户模糊搜索
+     */
+    fun search(userName: String): List<MaaUserInfo> {
+        val patterns = if (isAllChinese(userName)) {
+            listOf(
+                userName
+            )
+        } else {
+            listOf(userName)
+        }
+        return userRepository.searchUsers(
+            patterns[0]
+        ).take(10)
+    }
+
+    private fun isAllChinese(input: String): Boolean {
+        return input.all { it in '\u4e00'..'\u9fa5' }
+    }
 }

--- a/src/main/kotlin/plus/maa/backend/service/UserService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/UserService.kt
@@ -5,7 +5,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import plus.maa.backend.common.MaaStatusCode
-import plus.maa.backend.common.utils.PinyinUtil
 import plus.maa.backend.controller.request.user.LoginDTO
 import plus.maa.backend.controller.request.user.PasswordResetDTO
 import plus.maa.backend.controller.request.user.RegisterDTO
@@ -21,7 +20,6 @@ import plus.maa.backend.service.jwt.JwtInvalidException
 import plus.maa.backend.service.jwt.JwtService
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import com.github.houbb.opencc4j.util.ZhConverterUtil
 
 /**
  * @author AnselYuki
@@ -231,13 +229,13 @@ class UserService(
     fun search(userName: String): List<MaaUserInfo> {
         val patterns = if (isAllChinese(userName)) {
             listOf(
-                userName
+                userName,
             )
         } else {
             listOf(userName)
         }
         return userRepository.searchUsers(
-            patterns[0]
+            patterns[0],
         ).take(10)
     }
 

--- a/src/main/kotlin/plus/maa/backend/service/UserService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/UserService.kt
@@ -1,6 +1,8 @@
 package plus.maa.backend.service
 
 import org.springframework.dao.DuplicateKeyException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
@@ -220,25 +222,17 @@ class UserService(
         operator fun get(id: String): MaaUser? = userMap[id]
         fun getOrDefault(id: String) = get(id) ?: MaaUser.UNKNOWN
     }
-    
+
     fun get(userId: String): MaaUserInfo? = userRepository.findByUserId(userId)?.run(::MaaUserInfo)
 
     /**
      * 用户模糊搜索
      */
-    fun search(userName: String): List<MaaUserInfo> {
-        val patterns = if (isAllChinese(userName)) {
-            listOf(
-                userName,
-            )
-        } else {
-            listOf(userName)
-        }
-        return userRepository.searchUsers(
-            patterns[0],
-        ).take(10)
+    fun search(userName: String, pageable: Pageable): Page<MaaUserInfo> {
+        return userRepository.searchUsers(userName, pageable)
     }
 
+    @Suppress("unused")
     private fun isAllChinese(input: String): Boolean {
         return input.all { it in '\u4e00'..'\u9fa5' }
     }

--- a/src/main/kotlin/plus/maa/backend/service/model/CommentStatus.kt
+++ b/src/main/kotlin/plus/maa/backend/service/model/CommentStatus.kt
@@ -1,0 +1,9 @@
+package plus.maa.backend.service.model
+
+enum class CommentStatus {
+
+    ENABLED,
+
+    DISABLED
+
+}

--- a/src/main/kotlin/plus/maa/backend/service/model/CommentStatus.kt
+++ b/src/main/kotlin/plus/maa/backend/service/model/CommentStatus.kt
@@ -4,6 +4,5 @@ enum class CommentStatus {
 
     ENABLED,
 
-    DISABLED
-
+    DISABLED,
 }


### PR DESCRIPTION
#183 增加用户接口模糊搜索
但是算法还没有想好暂时只能精确搜索
格式如下
```
{
    "status_code": 200,
    "data": [
        {
            "id": "xxxxx",
            "user_name": "萨拉托加",
            "activated": false
        }
    ]
}
```
需要考虑汉拼转换，简繁转换，作者热度等...？
提供了PinYinUtil工具类为后续使用
p.s. pr融合了#182 的commit