### PR TITLE
feat: 首页接口使用已有字段组装content

### DIFF
--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -511,9 +511,6 @@ class CopilotService(
             "id" to 300L,
         )
 
-
-        val Q = mutableListOf<Map<*, *>>()
-
         @JvmStatic
         fun getHotScore(copilot: Copilot, lastWeekLike: Long, lastWeekDislike: Long): Double {
             val now = LocalDateTime.now()


### PR DESCRIPTION
等同于移除在首页列表移除不必要的actions字段

前端适配 [#392](https://github.com/MaaAssistantArknights/maa-copilot-frontend/pull/392)