### PR TITLE
bugfix:还原空检查,修复了MongoDB查询时的UncategorizedMongoDbException

### DIFF
--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -265,7 +265,7 @@ class CopilotService(
         // 标题、描述、神秘代码
         val queryObj = Query().addCriteria(criteriaObj)
 
-        segmentService.getSegment(request.document).let { words ->
+        segmentService.getSegment(request.document).takeIf { it.isNotEmpty() }?.let { words ->
             val c = TextCriteria.forDefaultLanguage().apply {
                 words.forEach { word -> matchingPhrase(word) }
             }


### PR DESCRIPTION
我的MongoDB版本（latest）-->若线上版本支持这样的查询也许不用修复？

最新的一次对CopilotService的更改疑似漏掉了空检查，使得MongoDB查询时在没有搜索词时也添加了一个空的文本搜索条件，导致抛出UncategorizedMongoDbException
![image](https://github.com/user-attachments/assets/6bab7a12-6d43-4989-b0fe-a44029c23e9f)
![image](https://github.com/user-attachments/assets/7f7996c5-26fa-4ace-8651-f6b283db2628)

修复后能正常查询
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/827b74ac-1803-4fb7-a73f-a50ec5044963" />
