### PR TITLE
fix: swagger doc authorization error

### DIFF
--- a/src/main/kotlin/plus/maa/backend/config/doc/SpringDocConfig.kt
+++ b/src/main/kotlin/plus/maa/backend/config/doc/SpringDocConfig.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.models.ExternalDocumentation
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.info.License
+import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -60,6 +61,7 @@ class SpringDocConfig(
                 )
             },
         )
+        addSecurityItem(SecurityRequirement().addList(SECURITY_SCHEME_JWT))
     }
 
     @Bean


### PR DESCRIPTION
修复swagger文档测试中对于没有@Requirejwt注解的接口请求头中未携带jwt的错误