### PR TITLE
feat: 新增关注后查询onlyFollowing=false时优先显示关注者

### DIFF
--- a/src/main/kotlin/plus/maa/backend/controller/UserFollowController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/UserFollowController.kt
@@ -43,6 +43,14 @@ class UserFollowController(
         userFollowService.unfollow(helper.userId, followUserId),
     )
 
+    @Operation(summary = "查询是否关注某用户")
+    @ApiResponse(description = "是否关注结果")
+    @RequireJwt
+    @GetMapping("/status/{followUserId}")
+    fun isFollowing(@PathVariable followUserId: Long): MaaResult<Boolean> = success(
+        userFollowService.isFollowing(helper.userId, followUserId),
+    )
+
     @Operation(summary = "获取关注列表")
     @ApiResponse(description = "关注列表")
     @RequireJwt

--- a/src/main/kotlin/plus/maa/backend/repository/ktorm/UserKtormRepository.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/ktorm/UserKtormRepository.kt
@@ -164,6 +164,14 @@ class UserKtormRepository(
         }
     }
 
+    fun isFollowing(userId: Long, followUserId: Long): Boolean {
+        return database.from(UserFollows).select(UserFollows.userId)
+            .where { (UserFollows.userId eq userId) and (UserFollows.followUserId eq followUserId) }
+            .limit(1)
+            .map { it[UserFollows.userId] }
+            .isNotEmpty()
+    }
+
     override fun save(entity: UserEntity): UserEntity {
         return if (isNewEntity(entity)) {
             insertEntity(entity)

--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -231,6 +231,18 @@ class CopilotService(
         val cacheTimeout = AtomicLong()
         val cacheKey = AtomicReference<String?>()
         val setKey = AtomicReference<String>()
+
+        val followedUserIds: List<Long> = if (userId != null) {
+            database.from(UserFollows)
+                .select(UserFollows.followUserId)
+                .where { UserFollows.userId eq userId }
+                .map { row -> row[UserFollows.followUserId] }
+                .filterNotNull()
+        } else {
+            emptyList()
+        }
+        val prioritizeFollowing = followedUserIds.isNotEmpty()
+
         // 只缓存默认状态下热度和访问量排序的结果，并且最多只缓存前三页
         val keyword = request.document?.trim()
         val canUseHomeCache = request.page <= 3 &&
@@ -240,15 +252,7 @@ class CopilotService(
             request.operator.isNullOrBlank() &&
             request.copilotIds.isNullOrEmpty() &&
             !request.onlyFollowing
-        val followingUserIds: List<Long?>? = if (userId != null && !request.onlyFollowing) {
-            database.from(UserFollows)
-                .select(UserFollows.followUserId)
-                .where { UserFollows.userId eq userId }
-                .map { row -> row[UserFollows.followUserId] }
-        } else {
-            null
-        }
-        val prioritizeFollowing = !followingUserIds.isNullOrEmpty()
+
         if (canUseHomeCache && !prioritizeFollowing) {
             request.orderBy?.blankAsNull()
                 ?.let { key -> HOME_PAGE_CACHE_CONFIG[key] }
@@ -340,12 +344,6 @@ class CopilotService(
             }
         }
 
-        val followingUploaderIdQuery = userId?.let {
-            database.from(UserFollows)
-                .select(UserFollows.followUserId)
-                .where { UserFollows.userId eq it }
-        }
-
         val filteredCopilotsSeq = database.copilots.filter {
             val conditions = ArrayList<ColumnDeclaring<Boolean>>()
             conditions += ArgumentExpression(true, BooleanSqlType)
@@ -365,8 +363,13 @@ class CopilotService(
             if (inCopilotIds != null) {
                 conditions += it.copilotId inList inCopilotIds
             }
-            if (request.onlyFollowing && followingUploaderIdQuery != null) {
-                conditions += it.uploaderId inList followingUploaderIdQuery
+            if (request.onlyFollowing) {
+                if (followedUserIds.isNotEmpty()) {
+                    conditions += it.uploaderId inList followedUserIds
+                } else {
+                    // 如果要求只看关注但没关注任何人，直接构造一个永远为假的条件或返回空
+                    conditions += ArgumentExpression(false, BooleanSqlType)
+                }
             }
             if (includeOps != null) {
                 conditions += it.copilotId inList (
@@ -387,8 +390,8 @@ class CopilotService(
 
         val copilotsSeq = filteredCopilotsSeq.sortedBy(
             {
-                if (prioritizeFollowing && followingUploaderIdQuery != null) {
-                    (it.uploaderId inList followingUploaderIdQuery).desc()
+                if (prioritizeFollowing && !request.onlyFollowing) {
+                    (it.uploaderId inList followedUserIds).desc()
                 } else {
                     ArgumentExpression(true, BooleanSqlType).desc()
                 }
@@ -408,35 +411,18 @@ class CopilotService(
             },
         ).drop((page - 1) * limit).take(limit)
 
-        val resultAgg = if (keyword.isNullOrEmpty() &&
-            request.levelKeyword.isNullOrBlank() &&
-            request.uploaderId != null &&
-            request.uploaderId != ME &&
-            request.operator.isNullOrBlank() &&
-            request.copilotIds.isNullOrEmpty()
-        ) {
-            val r = copilotsSeq.toList()
-            val count = filteredCopilotsSeq.count()
-            val hasNext = count > (page * limit)
-            (r to count) to hasNext
-        } else {
-            val r = copilotsSeq.toList()
-            val count = filteredCopilotsSeq.count()
-            val hasNext = count > (page * limit)
-            (r to count) to hasNext
-        }
-
-        val count = resultAgg.first.second
-        val copilots: List<CopilotEntity> = resultAgg.first.first
-        val hasNext = resultAgg.second
+        // 执行查询
+        val copilots = copilotsSeq.toList()
+        val count = filteredCopilotsSeq.count()
+        val hasNext = count > (page * limit)
 
         val userIds = copilots.map { it.uploaderId }
 
         // 填充前端所需信息
         val maaUsers = hashMapOf<Long, UserEntity>()
-        val remainingUserIds = userIds.filter { userId ->
-            val info = Cache.getMaaUserCache(userId.toString())?.also {
-                maaUsers[userId] = it
+        val remainingUserIds = userIds.filter { uId ->
+            val info = Cache.getMaaUserCache(uId.toString())?.also {
+                maaUsers[uId] = it
             }
             info == null
         }.toList()
@@ -462,9 +448,9 @@ class CopilotService(
                 .groupBy { it.copilotId }
                 .mapValues { it.value.size.toLong() }
             copilotIds.forEach { copilotId ->
-                val count = existedCount[copilotId] ?: 0
-                commentsCount[copilotId] = count
-                Cache.setCommentCountCache(copilotId, count)
+                val cCount = existedCount[copilotId] ?: 0
+                commentsCount[copilotId] = cCount
+                Cache.setCommentCountCache(copilotId, cCount)
             }
         }
 

--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -14,9 +14,11 @@ import org.ktorm.dsl.eq
 import org.ktorm.dsl.from
 import org.ktorm.dsl.inList
 import org.ktorm.dsl.like
+import org.ktorm.dsl.map
 import org.ktorm.dsl.notInList
 import org.ktorm.dsl.select
 import org.ktorm.dsl.where
+import org.ktorm.entity.count
 import org.ktorm.entity.drop
 import org.ktorm.entity.filter
 import org.ktorm.entity.forEach
@@ -231,14 +233,23 @@ class CopilotService(
         val setKey = AtomicReference<String>()
         // 只缓存默认状态下热度和访问量排序的结果，并且最多只缓存前三页
         val keyword = request.document?.trim()
-        if (request.page <= 3 &&
+        val canUseHomeCache = request.page <= 3 &&
             keyword.isNullOrEmpty() &&
             request.levelKeyword.isNullOrBlank() &&
             request.uploaderId.isNullOrBlank() &&
             request.operator.isNullOrBlank() &&
             request.copilotIds.isNullOrEmpty() &&
             !request.onlyFollowing
-        ) {
+        val followingUserIds: List<Long?>? = if (userId != null && !request.onlyFollowing) {
+            database.from(UserFollows)
+                .select(UserFollows.followUserId)
+                .where { UserFollows.userId eq userId }
+                .map { row -> row[UserFollows.followUserId] }
+        } else {
+            null
+        }
+        val prioritizeFollowing = !followingUserIds.isNullOrEmpty()
+        if (canUseHomeCache && !prioritizeFollowing) {
             request.orderBy?.blankAsNull()
                 ?.let { key -> HOME_PAGE_CACHE_CONFIG[key] }
                 ?.let { t ->
@@ -329,7 +340,13 @@ class CopilotService(
             }
         }
 
-        val copilotsSeq = database.copilots.filter {
+        val followingUploaderIdQuery = userId?.let {
+            database.from(UserFollows)
+                .select(UserFollows.followUserId)
+                .where { UserFollows.userId eq it }
+        }
+
+        val filteredCopilotsSeq = database.copilots.filter {
             val conditions = ArrayList<ColumnDeclaring<Boolean>>()
             conditions += ArgumentExpression(true, BooleanSqlType)
             conditions += it.delete eq false
@@ -348,12 +365,8 @@ class CopilotService(
             if (inCopilotIds != null) {
                 conditions += it.copilotId inList inCopilotIds
             }
-            if (request.onlyFollowing && userId != null) {
-                conditions += it.uploaderId inList (
-                    database.from(UserFollows)
-                        .select(UserFollows.followUserId)
-                        .where { UserFollows.userId eq userId }
-                    )
+            if (request.onlyFollowing && followingUploaderIdQuery != null) {
+                conditions += it.uploaderId inList followingUploaderIdQuery
             }
             if (includeOps != null) {
                 conditions += it.copilotId inList (
@@ -370,19 +383,30 @@ class CopilotService(
                     )
             }
             conditions.reduce { a, b -> a and b }
-        }.sortedBy {
-            val ord = when (request.orderBy ?: "id") {
-                "hot" -> it.hotScore
-                "id" -> it.copilotId
-                "views" -> it.views
-                else -> it.copilotId
-            }
-            if (request.desc) {
-                ord.desc()
-            } else {
-                ord.asc()
-            }
-        }.drop((page - 1) * limit).take(limit)
+        }
+
+        val copilotsSeq = filteredCopilotsSeq.sortedBy(
+            {
+                if (prioritizeFollowing && followingUploaderIdQuery != null) {
+                    (it.uploaderId inList followingUploaderIdQuery).desc()
+                } else {
+                    ArgumentExpression(true, BooleanSqlType).desc()
+                }
+            },
+            {
+                val ord = when (request.orderBy ?: "id") {
+                    "hot" -> it.hotScore
+                    "id" -> it.copilotId
+                    "views" -> it.views
+                    else -> it.copilotId
+                }
+                if (request.desc) {
+                    ord.desc()
+                } else {
+                    ord.asc()
+                }
+            },
+        ).drop((page - 1) * limit).take(limit)
 
         val resultAgg = if (keyword.isNullOrEmpty() &&
             request.levelKeyword.isNullOrBlank() &&
@@ -392,13 +416,14 @@ class CopilotService(
             request.copilotIds.isNullOrEmpty()
         ) {
             val r = copilotsSeq.toList()
-            val count = copilotsSeq.totalRecordsInAllPages
+            val count = filteredCopilotsSeq.count()
             val hasNext = count > (page * limit)
             (r to count) to hasNext
         } else {
             val r = copilotsSeq.toList()
-            val count = copilotsSeq.totalRecordsInAllPages
-            (r to count) to (r.size >= limit)
+            val count = filteredCopilotsSeq.count()
+            val hasNext = count > (page * limit)
+            (r to count) to hasNext
         }
 
         val count = resultAgg.first.second

--- a/src/main/kotlin/plus/maa/backend/service/follow/UserFollowService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/follow/UserFollowService.kt
@@ -28,6 +28,10 @@ class UserFollowService(
         userKtormRepository.unfollow(userId, followUserId)
     }
 
+    fun isFollowing(userId: Long, followUserId: Long): Boolean {
+        return userKtormRepository.isFollowing(userId, followUserId)
+    }
+
     fun getFollowingList(userId: Long, pageable: Pageable): PageImpl<MaaUserInfo> {
         val res = userKtormRepository.follows(userId).paginate(pageable)
         return PageImpl(res.map { it.toMaaUserInfo() }.toList(), pageable, res.totalElements)


### PR DESCRIPTION
## Summary by Sourcery

在保持现有过滤和分页行为的前提下，在查询结果中优先展示由已关注用户上传的 copilots。

新功能：
- 当存在已认证用户且查询未使用 `onlyFollowing` 参数时，优先展示来自已关注上传者的 copilots。

改进：
- 在过滤和排序中复用已关注用户的子查询，以避免重复。
- 调整总数统计和分页逻辑，使其基于过滤后的 copilot 集合，而不是基于分页后的序列。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prioritize copilots uploaded by followed users in query results while maintaining existing filtering and pagination behavior.

New Features:
- Show copilots from followed uploaders first when querying without onlyFollowing but with an authenticated user.

Enhancements:
- Reuse the followed users subquery across filtering and sorting to avoid duplication.
- Adjust total count and pagination logic to be based on the filtered copilot set instead of the paginated sequence.

</details>