### PR TITLE
Fix: sensitive word validation

### DIFF
--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -100,7 +100,11 @@ class CopilotService(
         log.error(e) { "解析copilot失败" }
         throw MaaResultException("解析copilot失败")
     }.apply {
-        sensitiveWordService.validate(doc)
+        // 只检测用户输入的文本内容，不检测整个对象序列化（避免 JSON 逗号误报）
+        doc?.let {
+            sensitiveWordService.validate(it.title)
+            it.details?.let { details -> sensitiveWordService.validate(details) }
+        }
         // 去除 name 的冗余部分
         groups?.forEach { group: Copilot.Groups ->
             group.opers?.forEach { oper: OperationGroup ->

--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -100,11 +100,7 @@ class CopilotService(
         log.error(e) { "解析copilot失败" }
         throw MaaResultException("解析copilot失败")
     }.apply {
-        // 只检测用户输入的文本内容，不检测整个对象序列化（避免 JSON 逗号误报）
-        doc?.let {
-            sensitiveWordService.validate(it.title)
-            it.details?.let { details -> sensitiveWordService.validate(details) }
-        }
+        sensitiveWordService.validate(doc)
         // 去除 name 的冗余部分
         groups?.forEach { group: Copilot.Groups ->
             group.opers?.forEach { oper: OperationGroup ->

--- a/src/main/kotlin/plus/maa/backend/service/sensitiveword/SensitiveWordService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/sensitiveword/SensitiveWordService.kt
@@ -18,6 +18,8 @@ class SensitiveWordService(
     private val log = KotlinLogging.logger {}
     private val wordTree = WordTree().apply {
         StopChar.STOP_WORD.remove('/')
+        StopChar.STOP_WORD.remove('(')
+        StopChar.STOP_WORD.remove(')')
         val path = maaCopilotProperties.sensitiveWord.path
         try {
             ctx.getResource(path).inputStream.bufferedReader().use { it.lines().forEach(::addWord) }


### PR DESCRIPTION
## Summary by Sourcery

调整敏感词校验逻辑，仅对用户提供的文本字段进行检查，并优化停用字符配置以减少误报。

Bug Fixes:
- 仅校验 copilot 文档标题和详情，而不是整个序列化对象，以避免在敏感词检查中因标点符号导致的误报。

Enhancements:
- 更新敏感词停用字符配置，在词匹配过程中将括号视为有效字符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust sensitive word validation to operate only on user-provided text fields and refine stop-character configuration to reduce false positives.

Bug Fixes:
- Validate only the copilot document title and details instead of the entire serialized object to avoid punctuation-related false positives in sensitive word checks.

Enhancements:
- Update sensitive word stop-character configuration to treat parentheses as valid characters during word matching.

</details>