### PR TITLE
feat: add multi-platform Docker build for amd64 and arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,12 @@ jobs:
           name: jar
           path: ./build/libs/*
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -87,5 +93,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary by Sourcery

在发布工作流程中添加多架构 Docker 镜像发布，以同时支持 amd64 和 arm64。

Build:
- 在发布工作流程中配置 QEMU 和 Docker Buildx，以启用跨平台 Docker 构建。
- 更新 Docker 构建并推送步骤，以生成适用于 linux/amd64 和 linux/arm64 平台的镜像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add multi-architecture Docker image publishing to the release workflow to support both amd64 and arm64.

Build:
- Configure QEMU and Docker Buildx in the release workflow to enable cross-platform Docker builds.
- Update the Docker build-and-push step to produce images for linux/amd64 and linux/arm64 platforms.

</details>