### PR TITLE
feat: 新增特关作者发作业站内信通知

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -17,10 +17,39 @@ create unique index if not exists idx_user_user_email on "user" (email);
 create table if not exists "user_follow"
 (
   user_id        bigint,
-  follow_user_id bigint       not null,
-  updated_at     timestamp(3) not null,
+  follow_user_id bigint                    not null,
+  special_follow boolean     default false not null,
+  updated_at     timestamp(3)              not null,
   primary key (user_id, follow_user_id)
 );
+create index if not exists idx_user_follow_special_author on user_follow (follow_user_id, special_follow);
+
+-- 站内信表
+create table if not exists site_message
+(
+  id          bigserial primary key,
+  receiver_id bigint       not null,
+  sender_id   bigint       not null,
+  sender_name text         not null,
+  type        text         not null,
+  title       text         not null,
+  content     text         not null,
+  copilot_id  bigint,
+  read_at     timestamp(3),
+  created_at  timestamp(3) not null
+);
+comment on table site_message is '站内信表';
+comment on column site_message.receiver_id is '接收用户ID';
+comment on column site_message.sender_id is '发送/触发用户ID';
+comment on column site_message.sender_name is '发送/触发用户名称快照';
+comment on column site_message.type is '站内信类型';
+comment on column site_message.title is '站内信标题';
+comment on column site_message.content is '站内信内容';
+comment on column site_message.copilot_id is '关联作业ID';
+comment on column site_message.read_at is '已读时间';
+comment on column site_message.created_at is '创建时间';
+create index if not exists idx_site_message_receiver_created on site_message (receiver_id, created_at desc);
+create index if not exists idx_site_message_receiver_read on site_message (receiver_id, read_at);
 
 -- 作业表
 create table if not exists copilot
@@ -202,3 +231,5 @@ ALTER SEQUENCE IF EXISTS comments_area_id_seq RESTART WITH 1;
 ALTER SEQUENCE IF EXISTS copilot_set_id_seq RESTART WITH 1;
 -- ark_level 表的 id 从 1 开始
 ALTER SEQUENCE IF EXISTS ark_level_id_seq RESTART WITH 1;
+-- site_message 表的 id 从 1 开始
+ALTER SEQUENCE IF EXISTS site_message_id_seq RESTART WITH 1;

--- a/docker/migration_site_message.sql
+++ b/docker/migration_site_message.sql
@@ -1,0 +1,32 @@
+alter table user_follow
+  add column if not exists special_follow boolean default false not null;
+
+create index if not exists idx_user_follow_special_author on user_follow (follow_user_id, special_follow);
+
+create table if not exists site_message
+(
+  id          bigserial primary key,
+  receiver_id bigint       not null,
+  sender_id   bigint       not null,
+  sender_name text         not null,
+  type        text         not null,
+  title       text         not null,
+  content     text         not null,
+  copilot_id  bigint,
+  read_at     timestamp(3),
+  created_at  timestamp(3) not null
+);
+
+comment on table site_message is '站内信表';
+comment on column site_message.receiver_id is '接收用户ID';
+comment on column site_message.sender_id is '发送/触发用户ID';
+comment on column site_message.sender_name is '发送/触发用户名称快照';
+comment on column site_message.type is '站内信类型';
+comment on column site_message.title is '站内信标题';
+comment on column site_message.content is '站内信内容';
+comment on column site_message.copilot_id is '关联作业ID';
+comment on column site_message.read_at is '已读时间';
+comment on column site_message.created_at is '创建时间';
+
+create index if not exists idx_site_message_receiver_created on site_message (receiver_id, created_at desc);
+create index if not exists idx_site_message_receiver_read on site_message (receiver_id, read_at);

--- a/src/main/kotlin/plus/maa/backend/controller/MessageController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/MessageController.kt
@@ -1,0 +1,65 @@
+package plus.maa.backend.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import plus.maa.backend.common.controller.PagedDTO
+import plus.maa.backend.config.doc.RequireJwt
+import plus.maa.backend.config.security.AuthenticationHelper
+import plus.maa.backend.controller.response.MaaResult
+import plus.maa.backend.controller.response.MaaResult.Companion.success
+import plus.maa.backend.controller.response.message.SiteMessageInfo
+import plus.maa.backend.controller.response.message.UnreadMessageCountInfo
+import plus.maa.backend.service.SiteMessageService
+
+@RestController
+@RequestMapping("/message")
+@Tag(name = "SiteMessage", description = "站内信接口")
+class MessageController(
+    private val siteMessageService: SiteMessageService,
+    private val helper: AuthenticationHelper,
+) {
+    @Operation(summary = "分页查询站内信")
+    @ApiResponse(description = "站内信列表")
+    @RequireJwt
+    @GetMapping("/list")
+    fun list(
+        @RequestParam page: Int = 1,
+        @RequestParam size: Int = 10,
+        @RequestParam("unread_only") unreadOnly: Boolean = false,
+    ): MaaResult<PagedDTO<SiteMessageInfo>> {
+        return success(siteMessageService.list(helper.userId, page, size, unreadOnly))
+    }
+
+    @Operation(summary = "查询未读站内信数量")
+    @ApiResponse(description = "未读站内信数量")
+    @RequireJwt
+    @GetMapping("/unreadCount")
+    fun unreadCount(): MaaResult<UnreadMessageCountInfo> {
+        return success(siteMessageService.unreadCount(helper.userId))
+    }
+
+    @Operation(summary = "标记单条站内信已读")
+    @ApiResponse(description = "标记结果")
+    @RequireJwt
+    @PostMapping("/read/{id}")
+    fun read(@PathVariable id: Long): MaaResult<Unit> {
+        siteMessageService.markRead(helper.userId, id)
+        return success()
+    }
+
+    @Operation(summary = "标记全部站内信已读")
+    @ApiResponse(description = "标记结果")
+    @RequireJwt
+    @PostMapping("/readAll")
+    fun readAll(): MaaResult<Unit> {
+        siteMessageService.markAllRead(helper.userId)
+        return success()
+    }
+}

--- a/src/main/kotlin/plus/maa/backend/controller/MessageController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/MessageController.kt
@@ -46,20 +46,18 @@ class MessageController(
     }
 
     @Operation(summary = "标记单条站内信已读")
-    @ApiResponse(description = "标记结果")
+    @ApiResponse(description = "标记结果，true=确实标记成功，false=该消息不存在/已读/不属于当前用户")
     @RequireJwt
     @PostMapping("/read/{id}")
-    fun read(@PathVariable id: Long): MaaResult<Unit> {
-        siteMessageService.markRead(helper.userId, id)
-        return success()
+    fun read(@PathVariable id: Long): MaaResult<Boolean> {
+        return success(siteMessageService.markRead(helper.userId, id))
     }
 
     @Operation(summary = "标记全部站内信已读")
-    @ApiResponse(description = "标记结果")
+    @ApiResponse(description = "本次实际标记已读的条数")
     @RequireJwt
     @PostMapping("/readAll")
-    fun readAll(): MaaResult<Unit> {
-        siteMessageService.markAllRead(helper.userId)
-        return success()
+    fun readAll(): MaaResult<Int> {
+        return success(siteMessageService.markAllRead(helper.userId))
     }
 }

--- a/src/main/kotlin/plus/maa/backend/controller/UserFollowController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/UserFollowController.kt
@@ -16,6 +16,7 @@ import plus.maa.backend.config.doc.RequireJwt
 import plus.maa.backend.config.security.AuthenticationHelper
 import plus.maa.backend.controller.response.MaaResult
 import plus.maa.backend.controller.response.MaaResult.Companion.success
+import plus.maa.backend.controller.response.user.FollowStatusInfo
 import plus.maa.backend.controller.response.user.MaaUserInfo
 import plus.maa.backend.service.follow.UserFollowService
 
@@ -42,6 +43,21 @@ class UserFollowController(
     fun unfollow(@PathVariable followUserId: Long): MaaResult<Unit> = success(
         userFollowService.unfollow(helper.userId, followUserId),
     )
+
+    @Operation(summary = "设置特别关注")
+    @ApiResponse(description = "设置特别关注结果")
+    @RequireJwt
+    @PostMapping("/special/{followUserId}")
+    fun specialFollow(@PathVariable followUserId: Long, @RequestParam status: Boolean): MaaResult<Unit> = success(
+        userFollowService.setSpecialFollow(helper.userId, followUserId, status),
+    )
+
+    @Operation(summary = "查询关注状态")
+    @ApiResponse(description = "关注状态")
+    @RequireJwt
+    @GetMapping("/status/{followUserId}")
+    fun getStatus(@PathVariable followUserId: Long): MaaResult<FollowStatusInfo> =
+        success(userFollowService.getStatus(helper.userId, followUserId))
 
     @Operation(summary = "获取关注列表")
     @ApiResponse(description = "关注列表")

--- a/src/main/kotlin/plus/maa/backend/controller/response/message/SiteMessageInfo.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/response/message/SiteMessageInfo.kt
@@ -1,0 +1,22 @@
+package plus.maa.backend.controller.response.message
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import plus.maa.backend.service.model.SiteMessageType
+import java.time.LocalDateTime
+
+@Serializable
+data class SiteMessageInfo(
+    val id: Long,
+    val type: SiteMessageType,
+    val title: String,
+    val content: String,
+    val senderId: Long,
+    val senderName: String,
+    val copilotId: Long?,
+    @Contextual
+    val createdAt: LocalDateTime,
+    @Contextual
+    val readAt: LocalDateTime?,
+    val isRead: Boolean,
+)

--- a/src/main/kotlin/plus/maa/backend/controller/response/message/UnreadMessageCountInfo.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/response/message/UnreadMessageCountInfo.kt
@@ -1,0 +1,8 @@
+package plus.maa.backend.controller.response.message
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UnreadMessageCountInfo(
+    val unreadCount: Long,
+)

--- a/src/main/kotlin/plus/maa/backend/controller/response/user/FollowStatusInfo.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/response/user/FollowStatusInfo.kt
@@ -1,0 +1,14 @@
+package plus.maa.backend.controller.response.user
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import java.time.Instant
+
+@Serializable
+data class FollowStatusInfo(
+    val following: Boolean,
+    val specialFollow: Boolean,
+    val relation: RelationType,
+    @Contextual
+    val followedAt: Instant? = null,
+)

--- a/src/main/kotlin/plus/maa/backend/controller/response/user/MaaUserInfo.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/response/user/MaaUserInfo.kt
@@ -19,6 +19,7 @@ data class MaaUserInfo(
     val followingCount: Int = 0,
     val fansCount: Int = 0,
     val relation: RelationType? = null,
+    val specialFollow: Boolean = false,
     @Contextual val followedAt: Instant? = null,
 ) {
     constructor(user: MaaUser) : this(

--- a/src/main/kotlin/plus/maa/backend/repository/entity/SiteMessageEntity.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/entity/SiteMessageEntity.kt
@@ -1,0 +1,42 @@
+package plus.maa.backend.repository.entity
+
+import org.ktorm.database.Database
+import org.ktorm.entity.Entity
+import org.ktorm.entity.sequenceOf
+import org.ktorm.schema.Table
+import org.ktorm.schema.datetime
+import org.ktorm.schema.enum
+import org.ktorm.schema.long
+import org.ktorm.schema.text
+import plus.maa.backend.service.model.SiteMessageType
+import java.time.LocalDateTime
+
+interface SiteMessageEntity : Entity<SiteMessageEntity> {
+    var id: Long
+    var receiverId: Long
+    var senderId: Long
+    var senderName: String
+    var type: SiteMessageType
+    var title: String
+    var content: String
+    var copilotId: Long?
+    var readAt: LocalDateTime?
+    var createdAt: LocalDateTime
+
+    companion object : Entity.Factory<SiteMessageEntity>()
+}
+
+object SiteMessages : Table<SiteMessageEntity>("site_message") {
+    val id = long("id").primaryKey().bindTo { it.id }
+    val receiverId = long("receiver_id").bindTo { it.receiverId }
+    val senderId = long("sender_id").bindTo { it.senderId }
+    val senderName = text("sender_name").bindTo { it.senderName }
+    val type = enum<SiteMessageType>("type").bindTo { it.type }
+    val title = text("title").bindTo { it.title }
+    val content = text("content").bindTo { it.content }
+    val copilotId = long("copilot_id").bindTo { it.copilotId }
+    val readAt = datetime("read_at").bindTo { it.readAt }
+    val createdAt = datetime("created_at").bindTo { it.createdAt }
+}
+
+val Database.siteMessages get() = sequenceOf(SiteMessages)

--- a/src/main/kotlin/plus/maa/backend/repository/entity/UserFollowEntity.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/entity/UserFollowEntity.kt
@@ -2,6 +2,7 @@ package plus.maa.backend.repository.entity
 
 import org.ktorm.entity.Entity
 import org.ktorm.schema.Table
+import org.ktorm.schema.boolean
 import org.ktorm.schema.datetime
 import org.ktorm.schema.long
 import java.time.LocalDateTime
@@ -9,6 +10,7 @@ import java.time.LocalDateTime
 interface UserFollowEntity : Entity<UserFollowEntity> {
     var userId: Long
     val followUserId: Long
+    var specialFollow: Boolean
     val updatedAt: LocalDateTime
 
     companion object : Entity.Factory<UserFollowEntity>()
@@ -17,5 +19,6 @@ interface UserFollowEntity : Entity<UserFollowEntity> {
 object UserFollows : Table<UserFollowEntity>("user_follow") {
     val userId = long("user_id").primaryKey().bindTo { it.userId }
     val followUserId = long("follow_user_id").primaryKey().bindTo { it.followUserId }
+    val specialFollow = boolean("special_follow").bindTo { it.specialFollow }
     val updatedAt = datetime("updated_at").bindTo { it.updatedAt }
 }

--- a/src/main/kotlin/plus/maa/backend/repository/ktorm/SiteMessageKtormRepository.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/ktorm/SiteMessageKtormRepository.kt
@@ -1,0 +1,121 @@
+package plus.maa.backend.repository.ktorm
+
+import org.ktorm.database.Database
+import org.ktorm.dsl.and
+import org.ktorm.dsl.batchInsert
+import org.ktorm.dsl.desc
+import org.ktorm.dsl.eq
+import org.ktorm.dsl.isNull
+import org.ktorm.dsl.update
+import org.ktorm.dsl.where
+import org.ktorm.entity.add
+import org.ktorm.entity.any
+import org.ktorm.entity.count
+import org.ktorm.entity.drop
+import org.ktorm.entity.filter
+import org.ktorm.entity.firstOrNull
+import org.ktorm.entity.removeIf
+import org.ktorm.entity.sortedBy
+import org.ktorm.entity.take
+import org.ktorm.entity.toList
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import plus.maa.backend.repository.entity.SiteMessageEntity
+import plus.maa.backend.repository.entity.SiteMessages
+import java.time.LocalDateTime
+
+@Repository
+class SiteMessageKtormRepository(
+    database: Database,
+) : KtormRepository<SiteMessageEntity, SiteMessages>(database, SiteMessages) {
+
+    fun insertAll(messages: List<SiteMessageEntity>) {
+        if (messages.isEmpty()) return
+        database.batchInsert(SiteMessages) {
+            messages.forEach { message ->
+                item {
+                    set(it.receiverId, message.receiverId)
+                    set(it.senderId, message.senderId)
+                    set(it.senderName, message.senderName)
+                    set(it.type, message.type)
+                    set(it.title, message.title)
+                    set(it.content, message.content)
+                    set(it.copilotId, message.copilotId)
+                    set(it.readAt, message.readAt)
+                    set(it.createdAt, message.createdAt)
+                }
+            }
+        }
+    }
+
+    fun findByReceiverId(receiverId: Long, unreadOnly: Boolean, pageable: Pageable): Page<SiteMessageEntity> {
+        var sequence = entities.filter { it.receiverId eq receiverId }
+        if (unreadOnly) {
+            sequence = sequence.filter { it.readAt.isNull() }
+        }
+        val total = sequence.count().toLong()
+        val data = sequence
+            .sortedBy({ it.createdAt.desc() }, { it.id.desc() })
+            .drop(pageable.offset.toInt())
+            .take(pageable.pageSize)
+            .toList()
+        return PageImpl(data, pageable, total)
+    }
+
+    fun countUnreadByReceiverId(receiverId: Long): Long {
+        return entities.filter {
+            (it.receiverId eq receiverId) and it.readAt.isNull()
+        }.count().toLong()
+    }
+
+    fun markRead(receiverId: Long, id: Long, readAt: LocalDateTime): Boolean {
+        val updatedRows = database.update(SiteMessages) {
+            set(it.readAt, readAt)
+            where {
+                (it.id eq id) and
+                    (it.receiverId eq receiverId) and
+                    it.readAt.isNull()
+            }
+        }
+        return updatedRows > 0
+    }
+
+    fun markAllRead(receiverId: Long, readAt: LocalDateTime): Int {
+        return database.update(SiteMessages) {
+            set(it.readAt, readAt)
+            where {
+                (it.receiverId eq receiverId) and it.readAt.isNull()
+            }
+        }
+    }
+
+    override fun findById(id: Any): SiteMessageEntity? {
+        return entities.firstOrNull { it.id eq (id as Long) }
+    }
+
+    override fun deleteById(id: Any): Boolean {
+        return entities.removeIf { it.id eq (id as Long) } > 0
+    }
+
+    override fun existsById(id: Any): Boolean {
+        return entities.any { it.id eq (id as Long) }
+    }
+
+    override fun getIdColumn(entity: SiteMessageEntity): Any = entity.id
+
+    override fun isNewEntity(entity: SiteMessageEntity): Boolean {
+        return entity.id == 0L || !existsById(entity.id)
+    }
+
+    fun insertEntity(entity: SiteMessageEntity): SiteMessageEntity {
+        entities.add(entity)
+        return entity
+    }
+
+    fun updateEntity(entity: SiteMessageEntity): SiteMessageEntity {
+        entity.flushChanges()
+        return entity
+    }
+}

--- a/src/main/kotlin/plus/maa/backend/repository/ktorm/SiteMessageKtormRepository.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/ktorm/SiteMessageKtormRepository.kt
@@ -2,7 +2,6 @@ package plus.maa.backend.repository.ktorm
 
 import org.ktorm.database.Database
 import org.ktorm.dsl.and
-import org.ktorm.dsl.batchInsert
 import org.ktorm.dsl.desc
 import org.ktorm.dsl.eq
 import org.ktorm.dsl.isNull
@@ -24,6 +23,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import plus.maa.backend.repository.entity.SiteMessageEntity
 import plus.maa.backend.repository.entity.SiteMessages
+import java.sql.Timestamp
 import java.time.LocalDateTime
 
 @Repository
@@ -31,21 +31,35 @@ class SiteMessageKtormRepository(
     database: Database,
 ) : KtormRepository<SiteMessageEntity, SiteMessages>(database, SiteMessages) {
 
-    fun insertAll(messages: List<SiteMessageEntity>) {
-        if (messages.isEmpty()) return
-        database.batchInsert(SiteMessages) {
-            messages.forEach { message ->
-                item {
-                    set(it.receiverId, message.receiverId)
-                    set(it.senderId, message.senderId)
-                    set(it.senderName, message.senderName)
-                    set(it.type, message.type)
-                    set(it.title, message.title)
-                    set(it.content, message.content)
-                    set(it.copilotId, message.copilotId)
-                    set(it.readAt, message.readAt)
-                    set(it.createdAt, message.createdAt)
-                }
+    /**
+     * 一条 SQL 完成对作者所有特关粉丝的「作业发布」站内信批量写入，
+     * 避免把粉丝列表与消息实体全部载入应用内存。返回受影响行数（即通知人数）。
+     */
+    fun insertCopilotPublishedNotifications(
+        senderId: Long,
+        senderName: String,
+        copilotId: Long,
+        title: String,
+        content: String,
+        createdAt: LocalDateTime,
+    ): Int {
+        val sql = """
+            INSERT INTO site_message
+              (receiver_id, sender_id, sender_name, type, title, content, copilot_id, read_at, created_at)
+            SELECT uf.user_id, ?, ?, 'COPILOT_PUBLISHED', ?, ?, ?, NULL, ?
+            FROM user_follow uf
+            WHERE uf.follow_user_id = ? AND uf.special_follow = TRUE
+        """.trimIndent()
+        return database.useConnection { conn ->
+            conn.prepareStatement(sql).use { ps ->
+                ps.setLong(1, senderId)
+                ps.setString(2, senderName)
+                ps.setString(3, title)
+                ps.setString(4, content)
+                ps.setLong(5, copilotId)
+                ps.setTimestamp(6, Timestamp.valueOf(createdAt))
+                ps.setLong(7, senderId)
+                ps.executeUpdate()
             }
         }
     }

--- a/src/main/kotlin/plus/maa/backend/repository/ktorm/UserKtormRepository.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/ktorm/UserKtormRepository.kt
@@ -21,11 +21,13 @@ import org.ktorm.entity.any
 import org.ktorm.entity.filter
 import org.ktorm.entity.firstOrNull
 import org.ktorm.entity.removeIf
+import org.ktorm.entity.sequenceOf
 import org.ktorm.entity.toList
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 import plus.maa.backend.repository.entity.MaaUser
 import plus.maa.backend.repository.entity.UserEntity
+import plus.maa.backend.repository.entity.UserFollowEntity
 import plus.maa.backend.repository.entity.UserFollows
 import plus.maa.backend.repository.entity.Users
 import java.time.LocalDateTime
@@ -107,6 +109,7 @@ class UserKtormRepository(
         database.insert(UserFollows) {
             set(it.userId, userId)
             set(it.followUserId, followUserId)
+            set(it.specialFollow, false)
             set(it.updatedAt, LocalDateTime.now())
         }
         database.update(Users) {
@@ -177,6 +180,42 @@ class UserKtormRepository(
             .toMap()
     }
 
+    fun findFollow(userId: Long, followUserId: Long): UserFollowEntity? {
+        return database.sequenceOf(UserFollows).firstOrNull {
+            (it.userId eq userId) and (it.followUserId eq followUserId)
+        }
+    }
+
+    fun setSpecialFollow(userId: Long, followUserId: Long, status: Boolean): Boolean {
+        val updatedRows = database.update(UserFollows) {
+            set(it.specialFollow, status)
+            where {
+                (it.userId eq userId) and (it.followUserId eq followUserId)
+            }
+        }
+        return updatedRows > 0
+    }
+
+    fun getSpecialFollowedTargetIds(userId: Long, targetIds: List<Long>): Set<Long> {
+        if (targetIds.isEmpty()) return emptySet()
+        return database.from(UserFollows)
+            .select(UserFollows.followUserId)
+            .where {
+                (UserFollows.userId eq userId) and
+                    (UserFollows.followUserId inList targetIds) and
+                    (UserFollows.specialFollow eq true)
+            }
+            .mapNotNull { it[UserFollows.followUserId] }
+            .toSet()
+    }
+
+    fun getSpecialFollowerIds(followUserId: Long): List<Long> {
+        return database.from(UserFollows)
+            .select(UserFollows.userId)
+            .where { (UserFollows.followUserId eq followUserId) and (UserFollows.specialFollow eq true) }
+            .mapNotNull { it[UserFollows.userId] }
+    }
+
     /**
      * 查询 fanIds 中谁关注了 userId，返回 fanId -> updatedAt 的映射
      */
@@ -216,6 +255,18 @@ class UserKtormRepository(
     fun isFollowing(userId: Long, followUserId: Long): Boolean {
         return database.from(UserFollows).select(UserFollows.userId)
             .where { (UserFollows.userId eq userId) and (UserFollows.followUserId eq followUserId) }
+            .limit(1)
+            .map { it[UserFollows.userId] }
+            .isNotEmpty()
+    }
+
+    fun isSpecialFollowing(userId: Long, followUserId: Long): Boolean {
+        return database.from(UserFollows).select(UserFollows.userId)
+            .where {
+                (UserFollows.userId eq userId) and
+                    (UserFollows.followUserId eq followUserId) and
+                    (UserFollows.specialFollow eq true)
+            }
             .limit(1)
             .map { it[UserFollows.userId] }
             .isNotEmpty()

--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -88,6 +88,7 @@ class CopilotService(
     private val properties: MaaCopilotProperties,
     private val sensitiveWordService: SensitiveWordService,
     private val segmentService: SegmentService,
+    private val siteMessageService: SiteMessageService,
 ) {
     private val log = KotlinLogging.logger { }
 
@@ -161,6 +162,13 @@ class CopilotService(
             }
         }
         segmentService.updateIndex(copilotId, entity.title, entity.details)
+        if (request.status == CopilotSetStatus.PUBLIC) {
+            try {
+                siteMessageService.notifyCopilotPublished(loginUserId, copilotId, entity.title)
+            } catch (e: Exception) {
+                log.error(e) { "创建作业发布站内信失败, copilotId: $copilotId" }
+            }
+        }
         return copilotId
     }
 

--- a/src/main/kotlin/plus/maa/backend/service/SiteMessageService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/SiteMessageService.kt
@@ -1,0 +1,78 @@
+package plus.maa.backend.service
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import plus.maa.backend.common.controller.PagedDTO
+import plus.maa.backend.controller.response.message.SiteMessageInfo
+import plus.maa.backend.controller.response.message.UnreadMessageCountInfo
+import plus.maa.backend.repository.entity.SiteMessageEntity
+import plus.maa.backend.repository.ktorm.SiteMessageKtormRepository
+import plus.maa.backend.repository.ktorm.UserKtormRepository
+import plus.maa.backend.service.model.SiteMessageType
+import java.time.LocalDateTime
+
+@Service
+class SiteMessageService(
+    private val siteMessageKtormRepository: SiteMessageKtormRepository,
+    private val userKtormRepository: UserKtormRepository,
+) {
+    fun notifyCopilotPublished(senderId: Long, copilotId: Long, copilotTitle: String) {
+        val receiverIds = userKtormRepository.getSpecialFollowerIds(senderId).distinct()
+        if (receiverIds.isEmpty()) return
+        val sender = userKtormRepository.findById(senderId) ?: return
+        val now = LocalDateTime.now()
+        val displayTitle = copilotTitle.ifBlank { "未命名作业" }
+        val messages = receiverIds.map { receiverId ->
+            SiteMessageEntity {
+                this.receiverId = receiverId
+                this.senderId = senderId
+                this.senderName = sender.userName
+                this.type = SiteMessageType.COPILOT_PUBLISHED
+                this.title = "特关作者发布了新作业"
+                this.content = "你特关的作者 @${sender.userName} 发布了新作业《$displayTitle》"
+                this.copilotId = copilotId
+                this.readAt = null
+                this.createdAt = now
+            }
+        }
+        siteMessageKtormRepository.insertAll(messages)
+    }
+
+    fun list(userId: Long, page: Int, size: Int, unreadOnly: Boolean): PagedDTO<SiteMessageInfo> {
+        val realPage = page.coerceAtLeast(1)
+        val realSize = size.coerceAtLeast(1)
+        val pageable = PageRequest.of(realPage - 1, realSize)
+        val messages = siteMessageKtormRepository.findByReceiverId(userId, unreadOnly, pageable)
+        return PagedDTO(
+            hasNext = messages.hasNext(),
+            page = messages.pageable.pageNumber + 1,
+            total = messages.totalElements,
+            data = messages.content.map(::toInfo),
+        )
+    }
+
+    fun unreadCount(userId: Long): UnreadMessageCountInfo {
+        return UnreadMessageCountInfo(siteMessageKtormRepository.countUnreadByReceiverId(userId))
+    }
+
+    fun markRead(userId: Long, id: Long) {
+        siteMessageKtormRepository.markRead(userId, id, LocalDateTime.now())
+    }
+
+    fun markAllRead(userId: Long) {
+        siteMessageKtormRepository.markAllRead(userId, LocalDateTime.now())
+    }
+
+    private fun toInfo(message: SiteMessageEntity) = SiteMessageInfo(
+        id = message.id,
+        type = message.type,
+        title = message.title,
+        content = message.content,
+        senderId = message.senderId,
+        senderName = message.senderName,
+        copilotId = message.copilotId,
+        createdAt = message.createdAt,
+        readAt = message.readAt,
+        isRead = message.readAt != null,
+    )
+}

--- a/src/main/kotlin/plus/maa/backend/service/SiteMessageService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/SiteMessageService.kt
@@ -8,7 +8,6 @@ import plus.maa.backend.controller.response.message.UnreadMessageCountInfo
 import plus.maa.backend.repository.entity.SiteMessageEntity
 import plus.maa.backend.repository.ktorm.SiteMessageKtormRepository
 import plus.maa.backend.repository.ktorm.UserKtormRepository
-import plus.maa.backend.service.model.SiteMessageType
 import java.time.LocalDateTime
 
 @Service
@@ -16,26 +15,20 @@ class SiteMessageService(
     private val siteMessageKtormRepository: SiteMessageKtormRepository,
     private val userKtormRepository: UserKtormRepository,
 ) {
-    fun notifyCopilotPublished(senderId: Long, copilotId: Long, copilotTitle: String) {
-        val receiverIds = userKtormRepository.getSpecialFollowerIds(senderId).distinct()
-        if (receiverIds.isEmpty()) return
-        val sender = userKtormRepository.findById(senderId) ?: return
-        val now = LocalDateTime.now()
+    fun notifyCopilotPublished(senderId: Long, copilotId: Long, copilotTitle: String): Int {
+        val sender = userKtormRepository.findById(senderId) ?: return 0
         val displayTitle = copilotTitle.ifBlank { "未命名作业" }
-        val messages = receiverIds.map { receiverId ->
-            SiteMessageEntity {
-                this.receiverId = receiverId
-                this.senderId = senderId
-                this.senderName = sender.userName
-                this.type = SiteMessageType.COPILOT_PUBLISHED
-                this.title = "特关作者发布了新作业"
-                this.content = "你特关的作者 @${sender.userName} 发布了新作业《$displayTitle》"
-                this.copilotId = copilotId
-                this.readAt = null
-                this.createdAt = now
-            }
-        }
-        siteMessageKtormRepository.insertAll(messages)
+        val title = "特关作者发布了新作业"
+        val content = "你特关的作者 @${sender.userName} 发布了新作业《$displayTitle》"
+        // 无特关粉丝时下面的 INSERT...SELECT 会自然插入 0 行并返回 0
+        return siteMessageKtormRepository.insertCopilotPublishedNotifications(
+            senderId = senderId,
+            senderName = sender.userName,
+            copilotId = copilotId,
+            title = title,
+            content = content,
+            createdAt = LocalDateTime.now(),
+        )
     }
 
     fun list(userId: Long, page: Int, size: Int, unreadOnly: Boolean): PagedDTO<SiteMessageInfo> {
@@ -55,12 +48,12 @@ class SiteMessageService(
         return UnreadMessageCountInfo(siteMessageKtormRepository.countUnreadByReceiverId(userId))
     }
 
-    fun markRead(userId: Long, id: Long) {
-        siteMessageKtormRepository.markRead(userId, id, LocalDateTime.now())
+    fun markRead(userId: Long, id: Long): Boolean {
+        return siteMessageKtormRepository.markRead(userId, id, LocalDateTime.now())
     }
 
-    fun markAllRead(userId: Long) {
-        siteMessageKtormRepository.markAllRead(userId, LocalDateTime.now())
+    fun markAllRead(userId: Long): Int {
+        return siteMessageKtormRepository.markAllRead(userId, LocalDateTime.now())
     }
 
     private fun toInfo(message: SiteMessageEntity) = SiteMessageInfo(

--- a/src/main/kotlin/plus/maa/backend/service/UserService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/UserService.kt
@@ -298,7 +298,10 @@ class UserService(
         val base = MaaUserInfo(userEntity)
         if (currentUserId == null) return base
         val relation = resolveRelation(currentUserId, targetId)
-        return base.copy(relation = relation)
+        return base.copy(
+            relation = relation,
+            specialFollow = currentUserId != targetId && userKtormRepository.isSpecialFollowing(currentUserId, targetId),
+        )
     }
 
     /**
@@ -316,6 +319,7 @@ class UserService(
         val iFollowIds = userKtormRepository.getFollowedTargetIds(currentUserId, ids)
         // 哪些目标关注了当前用户
         val theyFollowMeIds = userKtormRepository.getFollowerTargetIds(ids, currentUserId)
+        val specialFollowIds = userKtormRepository.getSpecialFollowedTargetIds(currentUserId, ids)
         return ids.mapNotNull { userMap[it] }.map { user ->
             val uid = user.userId
             val iFollow = uid in iFollowIds
@@ -327,7 +331,10 @@ class UserService(
                 theyFollow -> RelationType.FOLLOWED_BY
                 else -> RelationType.NONE
             }
-            MaaUserInfo(user).copy(relation = relation)
+            MaaUserInfo(user).copy(
+                relation = relation,
+                specialFollow = uid in specialFollowIds,
+            )
         }
     }
 

--- a/src/main/kotlin/plus/maa/backend/service/follow/UserFollowService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/follow/UserFollowService.kt
@@ -5,9 +5,11 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import plus.maa.backend.common.extensions.paginate
 import plus.maa.backend.common.extensions.toMaaUserInfo
+import plus.maa.backend.controller.response.user.FollowStatusInfo
 import plus.maa.backend.controller.response.user.MaaUserInfo
 import plus.maa.backend.controller.response.user.RelationType
 import plus.maa.backend.repository.ktorm.UserKtormRepository
+import java.time.LocalDateTime
 import java.time.ZoneId
 
 @Service
@@ -36,13 +38,18 @@ class UserFollowService(
         val targetIds = users.map { it.userId }
         // 查询关注时间
         val updatedAtMap = userKtormRepository.getFollowUpdatedAtMap(userId, targetIds)
+        val specialFollowIds = userKtormRepository.getSpecialFollowedTargetIds(userId, targetIds)
         // 查询哪些目标也关注了我（用于判断 MUTUAL）
         val mutualIds = userKtormRepository.getFollowerTargetIds(targetIds, userId)
         val enriched = users.map { user ->
             val info = user.toMaaUserInfo()
             val relation = if (user.userId in mutualIds) RelationType.MUTUAL else RelationType.FOLLOWING
             val followedAt = updatedAtMap[user.userId]?.atZone(ZoneId.systemDefault())?.toInstant()
-            info.copy(relation = relation, followedAt = followedAt)
+            info.copy(
+                relation = relation,
+                specialFollow = user.userId in specialFollowIds,
+                followedAt = followedAt,
+            )
         }
         return PageImpl(enriched, pageable, res.totalElements)
     }
@@ -53,14 +60,58 @@ class UserFollowService(
         val fanIds = users.map { it.userId }
         // 批量查询粉丝关注我的时间
         val fanUpdatedAtMap = userKtormRepository.getFansUpdatedAtMap(fanIds, userId)
+        val specialFollowIds = userKtormRepository.getSpecialFollowedTargetIds(userId, fanIds)
         // 查询我关注了哪些粉丝（用于判断 MUTUAL）
         val iFollowBackIds = userKtormRepository.getFollowedTargetIds(userId, fanIds)
         val enriched = users.map { user ->
             val info = user.toMaaUserInfo()
             val relation = if (user.userId in iFollowBackIds) RelationType.MUTUAL else RelationType.FOLLOWED_BY
             val followedAt = fanUpdatedAtMap[user.userId]?.atZone(ZoneId.systemDefault())?.toInstant()
-            info.copy(relation = relation, followedAt = followedAt)
+            info.copy(
+                relation = relation,
+                specialFollow = user.userId in specialFollowIds,
+                followedAt = followedAt,
+            )
         }
         return PageImpl(enriched, pageable, res.totalElements)
     }
+
+    fun setSpecialFollow(userId: Long, followUserId: Long, status: Boolean) {
+        if (!status && userKtormRepository.findFollow(userId, followUserId) == null) {
+            return
+        }
+        check(userId != followUserId) {
+            "不能特关自己哦～"
+        }
+        if (status) {
+            val followUser = userKtormRepository.findById(followUserId)
+            check(followUser != null && followUser.status > 0) {
+                "关注的用户不存在哦～"
+            }
+        }
+        val updated = userKtormRepository.setSpecialFollow(userId, followUserId, status)
+        check(updated || !status) {
+            "请先关注该用户哦～"
+        }
+    }
+
+    fun getStatus(userId: Long, followUserId: Long): FollowStatusInfo {
+        val follow = userKtormRepository.findFollow(userId, followUserId)
+        val theyFollowMe = userKtormRepository.isFollowing(followUserId, userId)
+        val relation = when {
+            userId == followUserId -> RelationType.SELF
+            follow != null && theyFollowMe -> RelationType.MUTUAL
+            follow != null -> RelationType.FOLLOWING
+            theyFollowMe -> RelationType.FOLLOWED_BY
+            else -> RelationType.NONE
+        }
+        return FollowStatusInfo(
+            following = follow != null,
+            specialFollow = follow?.specialFollow ?: false,
+            relation = relation,
+            followedAt = follow?.updatedAt.toInstantOrNull(),
+        )
+    }
+
+    private fun LocalDateTime?.toInstantOrNull() = this?.atZone(ZoneId.systemDefault())?.toInstant()
 }

--- a/src/main/kotlin/plus/maa/backend/service/model/SiteMessageType.kt
+++ b/src/main/kotlin/plus/maa/backend/service/model/SiteMessageType.kt
@@ -1,0 +1,8 @@
+package plus.maa.backend.service.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class SiteMessageType {
+    COPILOT_PUBLISHED,
+}


### PR DESCRIPTION
- 为用户关注关系增加特别关注状态和查询/设置接口
- 新增站内信表、实体、仓库、服务、响应模型和接口
- 作者上传公开作业后向特关粉丝生成站内信
- 补充站内信建表索引和已有数据库手工迁移 SQL

尝试实现（）

## Summary by Sourcery

为用户关系添加特别关注支持，并实现站内信机制，当作者发布新的公开 copilot 作业时通知其特别关注者。

New Features:
- 通过关注相关 API 支持标记和查询用户之间的特别关注关系。
- 引入带持久化的站内信系统，并提供 REST API 用于列出消息、查询未读数量以及标记消息为已读。

Enhancements:
- 在用户资料以及关注/粉丝列表响应中暴露特别关注状态。
- 当作者发布公开 copilot 作业时，向其特别关注者发送站内信通知。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add special-follow support to user relations and implement an in-app site messaging mechanism to notify special followers when authors publish new public copilot assignments.

New Features:
- Support marking and querying special follow relationships between users via follow APIs.
- Introduce a site message system with persistence and REST APIs for listing messages, querying unread counts, and marking messages as read.

Enhancements:
- Expose special follow status in user profile and follow/fan list responses.
- Send site messages to special followers when an author publishes a public copilot assignment.

</details>