### PR TITLE
添加视频类型的作业

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 开发技术栈
 
-- kotlin 2.3 (Java 25)
+- kotlin 2.4 (Java 25)
 - SpringBoot 4
   - spring-security
   - springdoc-openapi
@@ -20,6 +20,7 @@
 5. 运行 `./gradlew bootRun`, windows 环境为 `./gradlew.bat bootRun`
 6. 首次运行建议修改配置文件中的 `maa-copilot.task-cron.ark-level` 配置，这样可以将明日方舟中的关卡数据同步到你本地的
    数据库中，为了防止反复调用造成调试的麻烦，建议首次运行同步成功后再将配置修改回去
+7. 本项目使用 [ScalaR](https://github.com/ScalaR/ScalaR) 作为 OpenAPI 展示工具，本地启动时可通过 http://127.0.0.1:8848/scalar 调试
 
 ## 项目结构
 

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -26,6 +26,7 @@ create table if not exists "user_follow"
 create table if not exists copilot
 (
   copilot_id        bigserial primary key,
+  type              text             default 'PRTS' :: text not null,
   stage_name        text                                       not null,
   uploader_id       bigint                                     not null,
   views             bigint                                     not null,
@@ -46,6 +47,7 @@ create table if not exists copilot
   notification      boolean
 );
 comment on column copilot.copilot_id is '自增数字ID';
+comment on column copilot.type is '作业类型 PRTS/VIDEO [plus.maa.backend.service.model.CopilotType]';
 comment on column copilot.stage_name is '关卡名';
 comment on column copilot.uploader_id is '上传者id';
 comment on column copilot.views is '查看次数';
@@ -58,6 +60,7 @@ comment on column copilot.upload_time is '更新时间';
 comment on column copilot.content is '原始数据';
 comment on column copilot.delete is '作业状态，后端默认设置为公开以兼容历史逻辑[plus.maa.backend.service.model.CopilotSetStatus]';
 create index if not exists idx_copilot_stage_name on copilot (stage_name);
+create index if not exists idx_copilot_type on copilot (type);
 create index if not exists idx_copilot_view on copilot (views);
 create index if not exists idx_hot_score on copilot (hot_score);
 

--- a/src/main/kotlin/plus/maa/backend/config/NativeReflectionConfig.kt
+++ b/src/main/kotlin/plus/maa/backend/config/NativeReflectionConfig.kt
@@ -2,7 +2,12 @@ package plus.maa.backend.config
 
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 import org.springframework.context.annotation.Configuration
-import plus.maa.backend.controller.request.copilot.CopilotDTO
+import plus.maa.backend.controller.request.copilot.CopilotContentDTO
+import plus.maa.backend.controller.request.copilot.CopilotDeleteRequest
+import plus.maa.backend.controller.request.copilot.PrtsCUDRequest
+import plus.maa.backend.controller.request.copilot.PrtsDTO
+import plus.maa.backend.controller.request.copilot.VideoCUDRequest
+import plus.maa.backend.controller.request.copilot.VideoDTO
 import plus.maa.backend.repository.entity.gamedata.ArkActivity
 import plus.maa.backend.repository.entity.gamedata.ArkCharacter
 import plus.maa.backend.repository.entity.gamedata.ArkStage
@@ -27,6 +32,11 @@ import plus.maa.backend.repository.entity.gamedata.ArkZone
     Tile::class,
     ArkTower::class,
     ArkZone::class,
-    CopilotDTO::class,
+    CopilotContentDTO::class,
+    PrtsDTO::class,
+    VideoDTO::class,
+    PrtsCUDRequest::class,
+    VideoCUDRequest::class,
+    CopilotDeleteRequest::class,
 )
 class NativeReflectionConfig

--- a/src/main/kotlin/plus/maa/backend/config/doc/SpringDocConfig.kt
+++ b/src/main/kotlin/plus/maa/backend/config/doc/SpringDocConfig.kt
@@ -109,6 +109,26 @@ class SpringDocConfig(
         }
     }
 
+    /**
+     * swagger-core emits the CopilotCUDRequest discriminator's `propertyName` (`type`)
+     * but not its `mapping`. Without the mapping, openapi-generator expects the
+     * discriminator value to equal the subtype schema name (PrtsCUDRequest /
+     * VideoCUDRequest), which contradicts the runtime JSON that sends PRTS / VIDEO
+     * (kotlinx SerialName / Jackson JsonSubTypes.Type name). Patch in the mapping
+     * so generated clients discriminate on the values the API actually serves.
+     */
+    @Bean
+    fun addCopilotCudDiscriminatorMapping(): OpenApiCustomizer = OpenApiCustomizer { api ->
+        val base = api.components?.schemas?.get("CopilotCUDRequest") ?: return@OpenApiCustomizer
+        val disc = base.discriminator ?: return@OpenApiCustomizer
+        if (disc.mapping.isNullOrEmpty()) {
+            disc.mapping = linkedMapOf(
+                "PRTS" to "#/components/schemas/PrtsCUDRequest",
+                "VIDEO" to "#/components/schemas/VideoCUDRequest",
+            )
+        }
+    }
+
     companion object {
         const val SECURITY_SCHEME_JWT: String = "Jwt"
         const val SECURITY_SCHEME_API_KEY: String = "API_Key"

--- a/src/main/kotlin/plus/maa/backend/config/validation/JsonSchemaMatchValidator.kt
+++ b/src/main/kotlin/plus/maa/backend/config/validation/JsonSchemaMatchValidator.kt
@@ -1,5 +1,7 @@
 package plus.maa.backend.config.validation
 
+import com.fasterxml.jackson.core.JsonLocation
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.networknt.schema.InputFormat
 import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
@@ -18,7 +20,16 @@ class JsonSchemaMatchValidator : ConstraintValidator<JsonSchemaMatch, String> {
     override fun isValid(text: String?, ctx: ConstraintValidatorContext): Boolean {
         if (text == null) return true
         val validator = validators[schema] ?: return false
-        val assertions = validator.validate(text, InputFormat.JSON)
+        // content 不是合法 JSON 时，网络层校验器抛出含糊的 "Invalid input"，
+        // 其 cause 是带行/列/原因的 Jackson JsonParseException，这里展开成友好报错并转为 400
+        val assertions = try {
+            validator.validate(text, InputFormat.JSON)
+        } catch (e: Exception) {
+            ctx.disableDefaultConstraintViolation()
+            ctx.buildConstraintViolationWithTemplate("作业内容不是合法的 JSON: ${friendlyParseError(e)}")
+                .addConstraintViolation()
+            return false
+        }
         if (assertions.isEmpty()) {
             return true
         } else {
@@ -42,6 +53,24 @@ class JsonSchemaMatchValidator : ConstraintValidator<JsonSchemaMatch, String> {
             val jsonSchemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
             val schema = jsonSchemaFactory.getSchema(SchemaLocation.of("classpath:$path"))
             return path to schema
+        }
+
+        /**
+         * 从异常链中找出 Jackson 的 [JsonProcessingException]，返回带行/列与原因的友好信息；
+         * 找不到时回退到原始 message。
+         */
+        private fun friendlyParseError(e: Throwable): String {
+            var cur: Throwable? = e
+            while (cur != null) {
+                if (cur is JsonProcessingException) {
+                    val reason = cur.originalMessage?.trim()?.takeIf { it.isNotEmpty() }
+                        ?: cur.message ?: "无法解析"
+                    val loc: JsonLocation? = cur.location
+                    return if (loc != null) "第 ${loc.lineNr} 行 第 ${loc.columnNr} 列: $reason" else reason
+                }
+                cur = cur.cause
+            }
+            return e.message ?: "无法解析"
         }
     }
 }

--- a/src/main/kotlin/plus/maa/backend/config/validation/JsonSchemaMatchValidator.kt
+++ b/src/main/kotlin/plus/maa/backend/config/validation/JsonSchemaMatchValidator.kt
@@ -31,8 +31,10 @@ class JsonSchemaMatchValidator : ConstraintValidator<JsonSchemaMatch, String> {
 
     companion object {
         const val COPILOT_SCHEMA_JSON = "static/templates/maa-copilot-schema.json"
+        const val COPILOT_VIDEO_SCHEMA_JSON = "static/templates/maa-copilot-video-schema.json"
         val validators = mapOf(
             loadSchema(COPILOT_SCHEMA_JSON),
+            loadSchema(COPILOT_VIDEO_SCHEMA_JSON),
         )
 
         @Suppress("SameParameterValue")

--- a/src/main/kotlin/plus/maa/backend/controller/CopilotController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/CopilotController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 import plus.maa.backend.config.doc.RequireJwt
 import plus.maa.backend.config.security.AuthenticationHelper
 import plus.maa.backend.controller.request.copilot.CopilotCUDRequest
+import plus.maa.backend.controller.request.copilot.CopilotDeleteRequest
 import plus.maa.backend.controller.request.copilot.CopilotQueriesRequest
 import plus.maa.backend.controller.request.copilot.CopilotRatingReq
 import plus.maa.backend.controller.response.MaaResult
@@ -53,8 +54,8 @@ class CopilotController(
     @ApiResponse(description = "删除作业结果")
     @RequireJwt
     @PostMapping("/delete")
-    fun deleteCopilot(@RequestBody request: CopilotCUDRequest): MaaResult<Unit> {
-        copilotService.delete(helper.userId, request)
+    fun deleteCopilot(@RequestBody request: CopilotDeleteRequest): MaaResult<Unit> {
+        copilotService.delete(helper.userId, request.id)
         return success()
     }
 

--- a/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequest.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequest.kt
@@ -1,16 +1,59 @@
 package plus.maa.backend.controller.request.copilot
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import jakarta.validation.constraints.NotBlank
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 import plus.maa.backend.config.validation.JsonSchemaMatch
 import plus.maa.backend.config.validation.JsonSchemaMatchValidator
 import plus.maa.backend.service.model.CopilotSetStatus
 
+/**
+ * 作业 CUD 请求 (ADT)。作业类型由请求子类型决定，`type` 为 kotlinx/Jackson 的判别字段。
+ *
+ * - 运行时反序列化使用 kotlinx-serialization，判别字段默认为 `type`，
+ *   值由子类的 [SerialName] 提供。
+ * - OpenAPI/TS 客户端生成由 SpringDoc 通过 Jackson 反射完成，因此同时挂载 Jackson
+ *   的 [JsonTypeInfo]/[JsonSubTypes]，与 kotlinx 保持相同的判别字段与取值。
+ *   两套注解互不干扰：Jackson 忽略 [SerialName]，kotlinx 忽略 Jackson 注解。
+ */
 @Serializable
-data class CopilotCUDRequest(
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = PrtsCUDRequest::class, name = "PRTS"),
+    JsonSubTypes.Type(value = VideoCUDRequest::class, name = "VIDEO"),
+)
+sealed interface CopilotCUDRequest {
+    val content: String
+    val id: Long?
+    val status: CopilotSetStatus
+}
+
+@Serializable
+@SerialName("PRTS")
+data class PrtsCUDRequest(
     @field:NotBlank(message = "作业内容必填")
     @JsonSchemaMatch(schema = JsonSchemaMatchValidator.COPILOT_SCHEMA_JSON)
-    val content: String = "",
+    override val content: String = "",
+    override val id: Long? = null,
+    override val status: CopilotSetStatus = CopilotSetStatus.PUBLIC,
+) : CopilotCUDRequest
+
+@Serializable
+@SerialName("VIDEO")
+data class VideoCUDRequest(
+    @field:NotBlank(message = "作业内容必填")
+    @JsonSchemaMatch(schema = JsonSchemaMatchValidator.COPILOT_VIDEO_SCHEMA_JSON)
+    override val content: String = "",
+    override val id: Long? = null,
+    override val status: CopilotSetStatus = CopilotSetStatus.PUBLIC,
+) : CopilotCUDRequest
+
+/**
+ * 删除作业仅需 id，与类型无关，故独立出 CUD 的 sealed 体系，避免要求客户端附带 type 判别字段。
+ */
+@Serializable
+data class CopilotDeleteRequest(
     val id: Long? = null,
-    val status: CopilotSetStatus = CopilotSetStatus.PUBLIC,
 )

--- a/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequest.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequest.kt
@@ -13,12 +13,13 @@ import plus.maa.backend.service.model.CopilotSetStatus
  * 作业 CUD 请求 (ADT)。作业类型由请求子类型决定，`type` 为 kotlinx/Jackson 的判别字段。
  *
  * - 运行时反序列化使用 kotlinx-serialization，判别字段默认为 `type`，
- *   值由子类的 [SerialName] 提供。
+ *   值由子类的 [SerialName] 提供。为兼容不携带 `type` 的旧客户端，
+ *   缺失/为 null 的 `type` 默认视作 PRTS（见 [CopilotCUDRequestSerializer]）。
  * - OpenAPI/TS 客户端生成由 SpringDoc 通过 Jackson 反射完成，因此同时挂载 Jackson
  *   的 [JsonTypeInfo]/[JsonSubTypes]，与 kotlinx 保持相同的判别字段与取值。
  *   两套注解互不干扰：Jackson 忽略 [SerialName]，kotlinx 忽略 Jackson 注解。
  */
-@Serializable
+@Serializable(with = CopilotCUDRequestSerializer::class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(
     JsonSubTypes.Type(value = PrtsCUDRequest::class, name = "PRTS"),

--- a/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequestSerializer.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequestSerializer.kt
@@ -1,0 +1,72 @@
+package plus.maa.backend.controller.request.copilot
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * 兼容旧客户端的自定义序列化器：kotlinx 原生 sealed 多态要求请求体必须带 `type` 判别字段，
+ * 否则反序列化失败。旧 MAA 客户端上传/更新时不携带 `type`，此处将其默认为 PRTS，
+ * 使旧客户端无需改动即可继续作为自动化脚本作业工作。
+ *
+ * - deserialize: 读 JSON 对象，缺失/为 null 的 `type` 视作 PRTS，再按对应子类型反序列化。
+ * - serialize: 输出 `type` 判别字段 + 子类型字段（仅测试/内部回写会用到）。
+ */
+@OptIn(InternalSerializationApi::class)
+object CopilotCUDRequestSerializer : KSerializer<CopilotCUDRequest> {
+    override val descriptor: SerialDescriptor =
+        buildSerialDescriptor("plus.maa.backend.controller.request.copilot.CopilotCUDRequest", PolymorphicKind.SEALED)
+
+    override fun deserialize(decoder: Decoder): CopilotCUDRequest {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("CopilotCUDRequest 仅支持从 JSON 反序列化")
+        val element: JsonElement = jsonDecoder.decodeJsonElement()
+        val obj = element as? JsonObject
+            ?: throw SerializationException("CopilotCUDRequest 请求体必须是 JSON 对象")
+        val typeElement = obj["type"]
+        val type = when {
+            typeElement == null || typeElement is JsonNull -> "PRTS" // 兼容：未传 type 默认 PRTS
+            else -> typeElement.jsonPrimitive.content
+        }
+        val subSerializer = when (type) {
+            "PRTS" -> PrtsCUDRequest.serializer()
+            "VIDEO" -> VideoCUDRequest.serializer()
+            else -> throw SerializationException("未知的作业类型: $type")
+        }
+        // 子类型序列化器忽略多余的 type 字段 (ignoreUnknownKeys)
+        return jsonDecoder.json.decodeFromJsonElement(subSerializer, obj)
+    }
+
+    override fun serialize(encoder: Encoder, value: CopilotCUDRequest) {
+        val jsonEncoder = encoder as? JsonEncoder
+            ?: throw SerializationException("CopilotCUDRequest 仅支持序列化为 JSON")
+        val (subObj, typeName) = when (value) {
+            is PrtsCUDRequest ->
+                jsonEncoder.json.encodeToJsonElement(PrtsCUDRequest.serializer(), value).jsonObject to "PRTS"
+            is VideoCUDRequest ->
+                jsonEncoder.json.encodeToJsonElement(VideoCUDRequest.serializer(), value).jsonObject to "VIDEO"
+        }
+        val merged = buildJsonObject {
+            put("type", JsonPrimitive(typeName))
+            subObj.forEach { (k, v) -> if (k != "type") put(k, v) }
+        }
+        jsonEncoder.encodeJsonElement(merged)
+    }
+}

--- a/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotDTO.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotDTO.kt
@@ -1,30 +1,56 @@
 package plus.maa.backend.controller.request.copilot
 
-import jakarta.validation.constraints.NotBlank
 import kotlinx.serialization.Serializable
 import plus.maa.backend.repository.entity.Copilot
 
 /**
- * @author LoMu
- * Date  2023-01-10 19:50
+ * 作业内容解析模型 (ADT)。两种作业类型共享 stage_name / doc / opers / groups，
+ * 各自携带类型特有字段。类型由请求体 ([CopilotCUDRequest] 的子类型) 决定，
+ * 不依赖内容 JSON 内的判别字段。
  */
 @Serializable
-data class CopilotDTO(
-    // 关卡名
-    @field:NotBlank(message = "关卡名不能为空")
-    var stageName: String = "",
+sealed interface CopilotContentDTO {
+    /** 关卡名（会被规范化为 stageId） */
+    var stageName: String
+
+    /** 描述 */
+    val doc: Copilot.Doc?
+
+    /** 指定干员 */
+    val opers: List<Copilot.Operators>?
+
+    /** 群组 */
+    val groups: List<Copilot.Groups>?
+}
+
+/**
+ * 自动化脚本作业 (MAA copilot 格式)
+ */
+@Serializable
+data class PrtsDTO(
+    override var stageName: String = "",
     // 难度
     val difficulty: Int = 0,
     // 版本号(文档中说明:最低要求 maa 版本号，必选。保留字段)
-    @field:NotBlank(message = "最低要求 maa 版本不可为空")
     val minimumRequired: String,
-    // 指定干员
-    val opers: List<Copilot.Operators>? = null,
-    // 群组
-    val groups: List<Copilot.Groups>? = null,
+    override val opers: List<Copilot.Operators>? = null,
+    override val groups: List<Copilot.Groups>? = null,
     // 战斗中的操作
     val actions: List<Copilot.Action>? = null,
-    // 描述
-    val doc: Copilot.Doc? = null,
+    override val doc: Copilot.Doc? = null,
     val notification: Boolean = false,
-)
+) : CopilotContentDTO
+
+/**
+ * 视频作业。提供出战干员/群组列表与视频链接，无自动化操作。
+ */
+@Serializable
+data class VideoDTO(
+    override var stageName: String = "",
+    override val opers: List<Copilot.Operators>? = null,
+    override val groups: List<Copilot.Groups>? = null,
+    override val doc: Copilot.Doc? = null,
+    // 视频链接，用于跳转（或后续前端站内播放）
+    val videoUrl: String,
+    val notification: Boolean = false,
+) : CopilotContentDTO

--- a/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotQueriesRequest.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/request/copilot/CopilotQueriesRequest.kt
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Max
 import kotlinx.serialization.Serializable
 import org.springframework.web.bind.annotation.BindParam
 import plus.maa.backend.service.model.CopilotSetStatus
+import plus.maa.backend.service.model.CopilotType
 
 /**
  * @author LoMu
@@ -24,5 +25,6 @@ data class CopilotQueriesRequest(
     val language: String? = null,
     @field:BindParam("copilot_ids") var copilotIds: List<Long>? = null,
     val status: CopilotSetStatus? = null,
+    val type: CopilotType? = null,
     val onlyFollowing: Boolean = false,
 )

--- a/src/main/kotlin/plus/maa/backend/controller/response/copilot/CopilotInfo.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/response/copilot/CopilotInfo.kt
@@ -4,11 +4,16 @@ import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import plus.maa.backend.service.model.CommentStatus
 import plus.maa.backend.service.model.CopilotSetStatus
+import plus.maa.backend.service.model.CopilotType
 import java.time.LocalDateTime
 
 @Serializable
 data class CopilotInfo(
     val id: Long,
+    // 作业类型
+    val type: CopilotType,
+    // 视频链接，仅 VIDEO 类型有值，PRTS 为 null
+    val videoUrl: String? = null,
     @Contextual
     val uploadTime: LocalDateTime,
     val uploaderId: String,

--- a/src/main/kotlin/plus/maa/backend/repository/entity/CopilotEntity.kt
+++ b/src/main/kotlin/plus/maa/backend/repository/entity/CopilotEntity.kt
@@ -14,11 +14,15 @@ import org.ktorm.schema.text
 import org.ktorm.schema.varchar
 import plus.maa.backend.service.model.CommentStatus
 import plus.maa.backend.service.model.CopilotSetStatus
+import plus.maa.backend.service.model.CopilotType
 import java.time.LocalDateTime
 
 interface CopilotEntity : Entity<CopilotEntity> {
     // 自增数字ID
     var copilotId: Long
+
+    // 作业类型
+    var type: CopilotType
 
     // 关卡名
     var stageName: String
@@ -73,6 +77,7 @@ interface CopilotEntity : Entity<CopilotEntity> {
 
 object Copilots : Table<CopilotEntity>("copilot") {
     val copilotId = long("copilot_id").primaryKey().bindTo { it.copilotId }
+    val type = enum<CopilotType>("type").bindTo { it.type }
     val stageName = varchar("stage_name").bindTo { it.stageName }
     val uploaderId = long("uploader_id").bindTo { it.uploaderId }
     val views = long("views").bindTo { it.views }

--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.ktorm.database.Database
 import org.ktorm.dsl.and
 import org.ktorm.dsl.asc
@@ -36,8 +37,12 @@ import plus.maa.backend.common.extensions.removeQuotes
 import plus.maa.backend.common.extensions.requireNotNull
 import plus.maa.backend.config.external.MaaCopilotProperties
 import plus.maa.backend.controller.request.copilot.CopilotCUDRequest
-import plus.maa.backend.controller.request.copilot.CopilotDTO
+import plus.maa.backend.controller.request.copilot.CopilotContentDTO
 import plus.maa.backend.controller.request.copilot.CopilotQueriesRequest
+import plus.maa.backend.controller.request.copilot.PrtsCUDRequest
+import plus.maa.backend.controller.request.copilot.PrtsDTO
+import plus.maa.backend.controller.request.copilot.VideoCUDRequest
+import plus.maa.backend.controller.request.copilot.VideoDTO
 import plus.maa.backend.controller.request.copilot.CopilotRatingReq
 import plus.maa.backend.controller.response.MaaResultException
 import plus.maa.backend.controller.response.copilot.CopilotInfo
@@ -57,6 +62,7 @@ import plus.maa.backend.repository.ktorm.CopilotKtormRepository
 import plus.maa.backend.service.level.ArkLevelService
 import plus.maa.backend.service.model.CommentStatus
 import plus.maa.backend.service.model.CopilotSetStatus
+import plus.maa.backend.service.model.CopilotType
 import plus.maa.backend.service.model.RatingType
 import plus.maa.backend.service.segment.SegmentService
 import plus.maa.backend.service.sensitiveword.SensitiveWordService
@@ -92,10 +98,14 @@ class CopilotService(
     private val log = KotlinLogging.logger { }
 
     /**
-     * 将字符串解析为 [CopilotDTO], 检验敏感词并修正前端的冗余部分
+     * 按请求类型解析作业内容，检验敏感词并修正前端的冗余部分。
+     * 作业类型由请求子类型决定，不由内容 JSON 内字段决定。
      */
-    private fun String.parseToCopilotDto() = try {
-        json.decodeFromString<CopilotDTO>(this)
+    private fun CopilotCUDRequest.parseContent(): CopilotContentDTO = try {
+        when (this) {
+            is PrtsCUDRequest -> json.decodeFromString<PrtsDTO>(content)
+            is VideoCUDRequest -> json.decodeFromString<VideoDTO>(content)
+        }
     } catch (e: Exception) {
         log.error(e) { "解析copilot失败" }
         throw MaaResultException("解析copilot失败")
@@ -110,9 +120,11 @@ class CopilotService(
         opers?.forEach { operator: Copilot.Operators ->
             operator.name = operator.name.removeQuotes()
         }
-        // actions name 不是必须
-        actions?.forEach { action: Copilot.Action ->
-            action.name = action.name?.removeQuotes()
+        // actions name 不是必须（仅 PRTS）
+        if (this is PrtsDTO) {
+            actions?.forEach { action: Copilot.Action ->
+                action.name = action.name?.removeQuotes()
+            }
         }
         // 使用 stageId 存储作业关卡信息
         levelService.findByLevelIdFuzzy(stageName)?.stageId?.let {
@@ -120,14 +132,27 @@ class CopilotService(
         }
     }
 
+    /** 请求类型对应的作业类型 */
+    private fun CopilotCUDRequest.copilotType(): CopilotType = when (this) {
+        is PrtsCUDRequest -> CopilotType.PRTS
+        is VideoCUDRequest -> CopilotType.VIDEO
+    }
+
+    /** 从原始内容 JSON 中提取 video_url（PRTS 为 null） */
+    private fun extractVideoUrl(content: String): String? =
+        runCatching {
+            json.parseToJsonElement(content).jsonObject["video_url"]?.jsonPrimitive?.content
+        }.getOrNull()
+
     /**
      * 上传新的作业
      */
     fun upload(loginUserId: Long, request: CopilotCUDRequest): Long {
-        val dto = request.content.parseToCopilotDto()
+        val dto = request.parseContent()
         val now = LocalDateTime.now()
 
         val entity = CopilotEntity {
+            this.type = request.copilotType()
             this.stageName = dto.stageName
             this.uploaderId = loginUserId
             this.views = 0L
@@ -149,10 +174,10 @@ class CopilotService(
         }
         copilotKtormRepository.insertEntity(entity)
         val copilotId = entity.copilotId
-
-        if (!dto.opers.isNullOrEmpty()) {
+        val opers = dto.opers
+        if (!opers.isNullOrEmpty()) {
             database.batchInsert(Operators) {
-                dto.opers.map { op ->
+                opers.map { op ->
                     item {
                         set(it.copilotId, copilotId)
                         set(it.name, op.name)
@@ -167,7 +192,7 @@ class CopilotService(
     /**
      * 根据作业id删除作业
      */
-    fun delete(loginUserId: Long, request: CopilotCUDRequest) = userEditCopilot(loginUserId, request.id) {
+    fun delete(loginUserId: Long, copilotIdToDelete: Long?) = userEditCopilot(loginUserId, copilotIdToDelete) {
         delete = true
         deleteTime = LocalDateTime.now()
     }.apply {
@@ -237,6 +262,7 @@ class CopilotService(
             request.uploaderId.isNullOrBlank() &&
             request.operator.isNullOrBlank() &&
             request.copilotIds.isNullOrEmpty() &&
+            request.type == null &&
             !request.onlyFollowing
         ) {
             request.orderBy?.blankAsNull()
@@ -333,6 +359,9 @@ class CopilotService(
             val conditions = ArrayList<ColumnDeclaring<Boolean>>()
             conditions += ArgumentExpression(true, BooleanSqlType)
             conditions += it.delete eq false
+            if (request.type != null) {
+                conditions += it.type eq request.type
+            }
             if (requestStatus != null) {
                 conditions += it.status eq requestStatus
             }
@@ -475,13 +504,19 @@ class CopilotService(
     }
 
     /**
-     * 增量更新
+     * 增量更新。作业类型不可更改，请求类型必须与已存储类型一致，否则 400。
      */
     fun update(loginUserId: Long, request: CopilotCUDRequest) {
         var cIdToDeleteCache: Long? = null
 
-        val dto = request.content.parseToCopilotDto()
+        val dto = request.parseContent()
+        val requestType = request.copilotType()
         userEditCopilot(loginUserId, request.id) {
+            // 作业类型不可更改
+            if (type != requestType) {
+                throw MaaResultException(400, "作业类型不可更改")
+            }
+
             segmentService.removeIndex(copilotId, title, details)
 
             // 从公开改为隐藏时，如果数据存在缓存中则需要清除缓存
@@ -499,9 +534,10 @@ class CopilotService(
             database.delete(Operators) {
                 it.copilotId eq copilotId
             }
-            if (!dto.opers.isNullOrEmpty()) {
+            val opers = dto.opers
+            if (!opers.isNullOrEmpty()) {
                 database.batchInsert(Operators) {
-                    dto.opers.map { op ->
+                    opers.map { op ->
                         item {
                             set(it.copilotId, copilotId)
                             set(it.name, op.name)
@@ -563,6 +599,8 @@ class CopilotService(
 
     private fun CopilotEntity.format(rating: RatingEntity?, userName: String, commentsCount: Long) = CopilotInfo(
         id = copilotId,
+        type = type,
+        videoUrl = if (type == CopilotType.VIDEO) extractVideoUrl(content) else null,
         uploadTime = uploadTime,
         uploaderId = uploaderId.toString(),
         uploader = userName,

--- a/src/main/kotlin/plus/maa/backend/service/model/CopilotType.kt
+++ b/src/main/kotlin/plus/maa/backend/service/model/CopilotType.kt
@@ -1,0 +1,15 @@
+package plus.maa.backend.service.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * 作业类型
+ */
+@Serializable
+enum class CopilotType {
+    /** 自动化脚本作业（MAA copilot 格式） */
+    PRTS,
+
+    /** 视频作业 */
+    VIDEO,
+}

--- a/src/main/resources/static/templates/maa-copilot-video-schema.json
+++ b/src/main/resources/static/templates/maa-copilot-video-schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Arknights Video Operation",
+  "description": "Video job content schema. Provides operator/group lists and a video link for a level, no automation actions.",
+  "properties": {
+    "stage_name": {
+      "$ref": "#/definitions/stage_name"
+    },
+    "doc": {
+      "$ref": "#/definitions/doc"
+    },
+    "opers": {
+      "type": "array",
+      "description": "Operator list.",
+      "items": {
+        "$ref": "#/definitions/operator"
+      }
+    },
+    "groups": {
+      "type": "array",
+      "description": "Group list.",
+      "items": {
+        "$ref": "#/definitions/group"
+      }
+    },
+    "video_url": {
+      "$ref": "#/definitions/video_url"
+    }
+  },
+  "required": [
+    "stage_name",
+    "doc",
+    "video_url"
+  ],
+  "definitions": {
+    "stage_name": {
+      "type": "string",
+      "description": "Arknights level id like obt/main/level_main_00-01"
+    },
+    "doc": {
+      "type": "object",
+      "description": "The title and detail description for this operation",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Operation title",
+          "minLength": 1
+        },
+        "details": {
+          "type": "string",
+          "description": "Operation description"
+        },
+        "title_color": {
+          "type": "string",
+          "description": "The color of title text displayed in Maa"
+        },
+        "details_color": {
+          "type": "string",
+          "description": "The color of details text displayed in Maa"
+        }
+      },
+      "required": [
+        "title",
+        "details"
+      ]
+    },
+    "operator": {
+      "type": "object",
+      "title": "Operator definition",
+      "description": "Arknights operator info",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The official full name of the operator in your language.",
+          "minLength": 1
+        },
+        "skill": {
+          "type": "integer",
+          "description": "The skill of the operator to use in the operation.",
+          "minimum": 1,
+          "maximum": 3,
+          "default": 1
+        },
+        "skill_usage": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3,
+          "default": 0
+        },
+        "requirements": {
+          "$ref": "#/definitions/operator_requirements"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "operator_requirements": {
+      "type": "object",
+      "description": "Operator requirements, empty by default.",
+      "properties": {
+        "elite": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2,
+          "default": 0
+        },
+        "level": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 90,
+          "default": 0
+        },
+        "skill_level": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10,
+          "default": 0
+        },
+        "module": {
+          "type": "integer",
+          "default": -1
+        },
+        "potentiality": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 6,
+          "default": 0
+        }
+      }
+    },
+    "group": {
+      "type": "object",
+      "description": "Operator group",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "opers": {
+          "type": "array",
+          "description": "Operators to be chosen from.",
+          "items": {
+            "$ref": "#/definitions/operator"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "opers"
+      ]
+    },
+    "video_url": {
+      "type": "string",
+      "description": "Video link for the operation. Must be http(s) and on an allowlisted host.",
+      "format": "uri",
+      "pattern": "^https?://",
+      "minLength": 8
+    }
+  }
+}

--- a/src/test/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequestSerializationTest.kt
+++ b/src/test/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequestSerializationTest.kt
@@ -12,7 +12,8 @@ import plus.maa.backend.service.model.CopilotSetStatus
 
 /**
  * Verifies the dual serialization contract of the sealed [CopilotCUDRequest]:
- * - kotlinx-serialization (runtime request body): discriminator `type`, snake_case.
+ * - kotlinx-serialization (runtime request body): discriminator `type`, snake_case,
+ *   and (compat) missing/null `type` defaults to PRTS so old MAA clients keep working.
  * - Jackson (SpringDoc/OpenAPI codegen): same discriminator + subtype mapping.
  *
  * If either side drifts, codegen produces a spec that doesn't match the runtime JSON.
@@ -55,8 +56,27 @@ class CopilotCUDRequestSerializationTest {
             CopilotCUDRequest.serializer(),
             VideoCUDRequest(content = "c", id = 3, status = CopilotSetStatus.PRIVATE),
         )
-        assertTrue(json.contains("\"type\":\"VIDEO\""), json)
-        assertTrue(json.contains("\"status\":\"PRIVATE\""), json)
+        assertTrue(json.contains("""type":"VIDEO"""), json)
+        assertTrue(json.contains("""status":"PRIVATE"""), json)
+    }
+
+    @Test
+    fun `kotlinx defaults missing type discriminator to PRTS for old-client compatibility`() {
+        // old MAA clients upload/update without a type field
+        val req: CopilotCUDRequest = ktx.decodeFromString(
+            """{"content":"{}","id":1,"status":"PUBLIC"}""",
+        )
+        assertTrue(req is PrtsCUDRequest)
+        assertEquals("{}", req.content)
+        assertEquals(1L, req.id)
+    }
+
+    @Test
+    fun `kotlinx treats explicit null type discriminator as PRTS`() {
+        val req: CopilotCUDRequest = ktx.decodeFromString(
+            """{"type":null,"content":"{}","id":2}""",
+        )
+        assertTrue(req is PrtsCUDRequest)
     }
 
     @Test
@@ -82,6 +102,6 @@ class CopilotCUDRequestSerializationTest {
         val json = jackson.writeValueAsString(
             PrtsCUDRequest(content = "c", id = 3, status = CopilotSetStatus.PRIVATE),
         )
-        assertTrue(json.contains("\"type\":\"PRTS\""), json)
+        assertTrue(json.contains("""type":"PRTS"""), json)
     }
 }

--- a/src/test/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequestSerializationTest.kt
+++ b/src/test/kotlin/plus/maa/backend/controller/request/copilot/CopilotCUDRequestSerializationTest.kt
@@ -1,0 +1,87 @@
+package plus.maa.backend.controller.request.copilot
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import plus.maa.backend.service.model.CopilotSetStatus
+
+/**
+ * Verifies the dual serialization contract of the sealed [CopilotCUDRequest]:
+ * - kotlinx-serialization (runtime request body): discriminator `type`, snake_case.
+ * - Jackson (SpringDoc/OpenAPI codegen): same discriminator + subtype mapping.
+ *
+ * If either side drifts, codegen produces a spec that doesn't match the runtime JSON.
+ */
+class CopilotCUDRequestSerializationTest {
+    @OptIn(ExperimentalSerializationApi::class)
+    private val ktx: Json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        encodeDefaults = true
+        namingStrategy = JsonNamingStrategy.SnakeCase
+    }
+
+    private val jackson = jacksonObjectMapper()
+
+    @Test
+    fun `kotlinx decodes PRTS discriminator to PrtsCUDRequest`() {
+        val req: CopilotCUDRequest = ktx.decodeFromString(
+            """{"type":"PRTS","content":"{}","id":7,"status":"PUBLIC"}""",
+        )
+        assertTrue(req is PrtsCUDRequest)
+        assertEquals("{}", req.content)
+        assertEquals(7L, req.id)
+    }
+
+    @Test
+    fun `kotlinx decodes VIDEO discriminator to VideoCUDRequest`() {
+        val req: CopilotCUDRequest = ktx.decodeFromString(
+            """{"type":"VIDEO","content":"{}","id":8}""",
+        )
+        assertTrue(req is VideoCUDRequest)
+        assertEquals(8L, req.id)
+        // status has a default; omitted in input should fall back to PUBLIC
+        assertEquals(CopilotSetStatus.PUBLIC, req.status)
+    }
+
+    @Test
+    fun `kotlinx encodes discriminator and snake_case fields`() {
+        val json = ktx.encodeToString(
+            CopilotCUDRequest.serializer(),
+            VideoCUDRequest(content = "c", id = 3, status = CopilotSetStatus.PRIVATE),
+        )
+        assertTrue(json.contains("\"type\":\"VIDEO\""), json)
+        assertTrue(json.contains("\"status\":\"PRIVATE\""), json)
+    }
+
+    @Test
+    fun `jackson decodes PRTS discriminator to PrtsCUDRequest`() {
+        val req: CopilotCUDRequest = jackson.readValue(
+            """{"type":"PRTS","content":"{}","id":7,"status":"PUBLIC"}""",
+        )
+        assertTrue(req is PrtsCUDRequest)
+        assertEquals(7L, req.id)
+    }
+
+    @Test
+    fun `jackson decodes VIDEO discriminator to VideoCUDRequest`() {
+        val req: CopilotCUDRequest = jackson.readValue(
+            """{"type":"VIDEO","content":"{}","id":8,"status":"PUBLIC"}""",
+        )
+        assertTrue(req is VideoCUDRequest)
+        assertEquals(8L, req.id)
+    }
+
+    @Test
+    fun `jackson encodes discriminator`() {
+        val json = jackson.writeValueAsString(
+            PrtsCUDRequest(content = "c", id = 3, status = CopilotSetStatus.PRIVATE),
+        )
+        assertTrue(json.contains("\"type\":\"PRTS\""), json)
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

添加一个多态的 copilot 分配模型，在整个 API、持久层、校验逻辑和 OpenAPI 规范中区分 PRTS 脚本与视频类型，同时保持对现有客户端的向后兼容。

New Features:
- 在现有 PRTS 脚本的基础上，引入对全新基于视频的 copilot 分配类型的支持，包括专用的请求/响应模型、JSON 模式以及在 API 中的类型区分。
- 在 copilot 查询响应中暴露分配类型和可选的视频 URL，并支持按类型过滤分配记录。

Enhancements:
- 将 copilot 内容处理重构为密封 ADT，分离 PRTS 与视频载荷，并在更新操作中强制分配类型不可更改。
- 改进 JSON 模式校验的错误信息，提供更友好的解析诊断，同时为视频 copilot 内容增加模式校验。
- 调整删除 API，改为使用与 copilot 类型无关的专用请求模型，并相应统一控制器/服务层的签名。
- 更新 OpenAPI 生成逻辑和原生反射提示，使多态的 copilot CUD 请求在客户端代码生成中通过 discriminator 映射得到正确表示。

Documentation:
- 更新 README 以反映 Kotlin 2.4 的使用情况，并文档化用于本地调试的基于 ScalaR 的 OpenAPI UI。

Tests:
- 添加序列化测试，验证多态 copilot CUD 请求在 kotlinx 与 Jackson 之间的互操作性，包括对缺少类型 discriminator 的旧客户端的向后兼容。

Chores:
- 扩展 copilot 记录的数据库模式，增加持久化的分配类型字段，将现有数据默认为 PRTS，并新增基于类型查询的索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a polymorphic copilot assignment model that distinguishes between PRTS script and video types across the API, persistence layer, validation, and OpenAPI spec, while preserving backward compatibility with existing clients.

New Features:
- Introduce support for a new video-based copilot assignment type alongside existing PRTS scripts, including dedicated request/response models, JSON schemas, and type discrimination in APIs.
- Expose assignment type and optional video URL in copilot query responses and allow filtering assignments by type.

Enhancements:
- Refactor copilot content handling into a sealed ADT, separating PRTS and video payloads and enforcing non-changeable assignment types on updates.
- Improve JSON schema validation error messages with user-friendly parse diagnostics and add schema validation for video copilot content.
- Adjust deletion API to use a dedicated request model independent of copilot type and align controller/service signatures accordingly.
- Update OpenAPI generation and native reflection hints to correctly represent the polymorphic copilot CUD request with discriminator mappings for client codegen compatibility.

Documentation:
- Update README to reflect Kotlin 2.4 usage and document the ScalaR-based OpenAPI UI for local debugging.

Tests:
- Add serialization tests to verify kotlinx and Jackson interoperability for polymorphic copilot CUD requests, including backward compatibility with clients missing the type discriminator.

Chores:
- Extend database schema for copilot records with a persisted assignment type column, defaulting existing data to PRTS and adding an index for type-based queries.

</details>